### PR TITLE
Add artifact hub ID

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,5 +1,5 @@
 # Artifact Hub repository metadata file
-repositoryID: TBD
+repositoryID: b0b4140a-b8a1-4166-bdf7-5089f3a73660
 owners:
   - name: RAD Security
     email: infrastructure@rad.security


### PR DESCRIPTION
#### What this PR does / why we need it
We need to set artifact hub repo ID to publish helm chart externally

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
