### PR TITLE
Add support for Openshift in rad-runtime

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.0.0
+version: 2.0.1
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://rad.security/hs-fs/hubfs/Supplementary%20COMBO@2x.png?width=655&height=229&name=Supplementary%20COMBO@2x.png
@@ -18,8 +18,8 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: added
-      description: Add first version of the chart
-  artifacthub.io/containsSecurityUpdates: "true"
+      description: Add experimental support for OpenShift and cri-o
+  artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source
       url: https://github.com/rad-security/plugins-helm-chart

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -63,18 +63,22 @@ When `rad-runtime
 - Filesystem information
 - Container information
 
-By default plugin uses `containerd` as a container runtime. If you are using `docker` container runtime, you can enable it by switching the collector to `docker` in the `values.yaml` file.
+By default the plugin uses `containerd` as a container runtime. If you are using `docker` or `crio-o` as your container runtime, you can enable it by configuring collectors in the `values.yaml` file.
 
 ```yaml
 runtime:
   enabled: true
-  collectors:
-    docker:
-      enabled: false
-      socket: /run/docker.sock
-    containerd:
-      enabled: true
-      socket: /run/containerd/containerd.sock
+  agent:
+    collectors:
+      containerd:
+        enabled: true
+        socket: /run/containerd/containerd.sock
+      crio:
+        enabled: false
+        socket: /run/crio/crio.sock
+      docker:
+        enabled: false
+        socket: /run/docker.sock
 ```
 
 Each plugin pod contains `agent` and `exporter` containers. The `agent` container is responsible for collecting runtime information from the nodes in the cluster. The `exporter` container is responsible for exporting the collected information to the RAD Security platform.
@@ -512,7 +516,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | runtime.exporter.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | runtime.exporter.resources.requests.memory | string | `"128Mi"` |  |
 | runtime.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-runtime"` |  |
-| runtime.image.tag | string | `"v0.1.0"` |  |
+| runtime.image.tag | string | `"v0.1.1"` |  |
 | runtime.nodeName | string | `""` |  |
 | runtime.nodeSelector | object | `{}` |  |
 | runtime.reachableVulnerabilitiesEnabled | bool | `true` |  |

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -488,8 +488,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | rad.base64SecretKey | string | `""` | The secret key part of the Access Key used in this cluster (base64). |
 | rad.clusterName | string | `""` | The name of the cluster you want displayed in RAD Security. |
 | rad.seccompProfile | object | `{"enabled":true}` | Enable seccompProfile for all RAD Security pods |
-| runtime.agent.collectors.containerd.enabled | bool | `true` |  |
+| runtime.agent.collectors.containerd.enabled | string | `nil` |  |
 | runtime.agent.collectors.containerd.socket | string | `"/run/containerd/containerd.sock"` |  |
+| runtime.agent.collectors.crio.enabled | string | `nil` |  |
+| runtime.agent.collectors.crio.socket | string | `"/run/crio/crio.sock"` |  |
 | runtime.agent.collectors.docker.enabled | bool | `false` |  |
 | runtime.agent.collectors.docker.socket | string | `"/run/docker.sock"` |  |
 | runtime.agent.collectors.runtimePath | string | `""` |  |
@@ -497,7 +499,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | runtime.agent.env.AGENT_TRACER_IGNORE_NAMESPACES | string | `"cert-manager,\nrad,\nkube-node-lease,\nkube-public,\nkube-system\n"` |  |
 | runtime.agent.eventQueueSize | int | `20000` |  |
 | runtime.agent.grpcServerBatchSize | int | `2000` |  |
-| runtime.agent.hostPID | bool | `false` |  |
+| runtime.agent.hostPID | string | `nil` |  |
 | runtime.agent.mounts.volumeMounts | list | `[]` |  |
 | runtime.agent.mounts.volumes | list | `[]` |  |
 | runtime.agent.resources.limits.cpu | string | `"200m"` |  |

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -518,7 +518,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | runtime.exporter.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | runtime.exporter.resources.requests.memory | string | `"128Mi"` |  |
 | runtime.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-runtime"` |  |
-| runtime.image.tag | string | `"v0.1.1"` |  |
+| runtime.image.tag | string | `"v0.1.2"` |  |
 | runtime.nodeName | string | `""` |  |
 | runtime.nodeSelector | object | `{}` |  |
 | runtime.reachableVulnerabilitiesEnabled | bool | `true` |  |

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -495,8 +495,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | runtime.agent.collectors.docker.enabled | bool | `false` |  |
 | runtime.agent.collectors.docker.socket | string | `"/run/docker.sock"` |  |
 | runtime.agent.collectors.runtimePath | string | `""` |  |
-| runtime.agent.env.AGENT_LOG_LEVEL | string | `"INFO"` |  |
-| runtime.agent.env.AGENT_TRACER_IGNORE_NAMESPACES | string | `"cert-manager,\nrad,\nkube-node-lease,\nkube-public,\nkube-system\n"` |  |
+| runtime.agent.env.LOG_LEVEL | string | `"INFO"` |  |
+| runtime.agent.env.TRACER_IGNORE_NAMESPACES | string | `"cert-manager,\nrad,\nksoc,\nkube-node-lease,\nkube-public,\nkube-system\n"` |  |
 | runtime.agent.eventQueueSize | int | `20000` |  |
 | runtime.agent.grpcServerBatchSize | int | `2000` |  |
 | runtime.agent.hostPID | string | `nil` |  |
@@ -509,7 +509,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | runtime.agent.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | runtime.agent.resources.requests.memory | string | `"128Mi"` |  |
 | runtime.enabled | bool | `false` |  |
-| runtime.exporter.env.EXPORTER_LOG_LEVEL | string | `"INFO"` |  |
+| runtime.exporter.env.LOG_LEVEL | string | `"INFO"` |  |
 | runtime.exporter.execFilters | list | `[]` | Allows to specify wildcard rules for filtering command arguments. |
 | runtime.exporter.resources.limits.cpu | string | `"500m"` |  |
 | runtime.exporter.resources.limits.ephemeral-storage | string | `"1Gi"` |  |

--- a/stable/rad-plugins/README.md.gotmpl
+++ b/stable/rad-plugins/README.md.gotmpl
@@ -63,18 +63,22 @@ When `rad-runtime
 - Filesystem information
 - Container information
 
-By default plugin uses `containerd` as a container runtime. If you are using `docker` container runtime, you can enable it by switching the collector to `docker` in the `values.yaml` file.
+By default the plugin uses `containerd` as a container runtime. If you are using `docker` or `crio-o` as your container runtime, you can enable it by configuring collectors in the `values.yaml` file.
 
 ```yaml
 runtime:
   enabled: true
-  collectors:
-    docker:
-      enabled: false
-      socket: /run/docker.sock
-    containerd:
-      enabled: true
-      socket: /run/containerd/containerd.sock
+  agent:
+    collectors:
+      containerd:
+        enabled: true
+        socket: /run/containerd/containerd.sock
+      crio:
+        enabled: false
+        socket: /run/crio/crio.sock
+      docker:
+        enabled: false
+        socket: /run/docker.sock
 ```
 
 Each plugin pod contains `agent` and `exporter` containers. The `agent` container is responsible for collecting runtime information from the nodes in the cluster. The `exporter` container is responsible for exporting the collected information to the RAD Security platform.

--- a/stable/rad-plugins/templates/openshift.yaml
+++ b/stable/rad-plugins/templates/openshift.yaml
@@ -1,14 +1,11 @@
 {{- if and .Values.openshift .Values.openshift.enabled -}}
+{{- if .Values.runtime.enabled }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: rad-scc
+  name: rad-runtime-scc
 allowHostDirVolumePlugin: true
-allowPrivilegedContainer: true
-allowHostIPC: true
-allowHostNetwork: true
 allowHostPID: true
-allowHostPorts: true
 allowedCapabilities:
   - SYS_ADMIN
   - SYSLOG
@@ -17,29 +14,45 @@ allowedCapabilities:
   - IPC_LOCK
   - NET_ADMIN
   - NET_RAW
-requiredDropCapabilities: null
-fsGroup:
-  type: RunAsAny
-groups: []
-priority: 0
 readOnlyRootFilesystem: true
 runAsUser:
   type: RunAsAny
-seLinuxContext:
-  type: RunAsAny
-supplementalGroups:
-  type: RunAsAny
+priority: 0
 seccompProfiles:
   - "*"
+seLinuxContext:
+  type: RunAsAny
 users:
-  - system:serviceaccount:{{ .Release.Namespace }}:rad-node-agent
+  - system:serviceaccount:{{ .Release.Namespace }}:rad-runtime
+volumes:
+  - "*"
+{{- end }}
+
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: rad-shared-scc
+readOnlyRootFilesystem: true
+priority: 1
+runAsUser:
+  type: MustRunAsRange
+  uidRangeMin: 65534
+  uidRangeMax: 65534
+requiredDropCapabilities:
+  - ALL
+seccompProfiles:
+  - "*"
+seLinuxContext:
+  type: RunAsAny
+users:
   - system:serviceaccount:{{ .Release.Namespace }}:rad-guard
   - system:serviceaccount:{{ .Release.Namespace }}:rad-sbom
   - system:serviceaccount:{{ .Release.Namespace }}:rad-sync
   - system:serviceaccount:{{ .Release.Namespace }}:rad-watch
 volumes:
-  - downwardAPI
-  - emptyDir
-  - hostPath
-  - secret
+  - "*"
+
+---
+
 {{- end -}}

--- a/stable/rad-plugins/templates/runtime/daemonset.yaml
+++ b/stable/rad-plugins/templates/runtime/daemonset.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.runtime .Values.runtime.enabled -}}
+{{- $openshiftEnabled := and .Values.openshift .Values.openshift.enabled }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -39,7 +40,8 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.workloads.imagePullSecretName }}
       {{- end }}
-      hostPID: {{ .Values.runtime.agent.hostPID }}
+      # hostPID is enabled by default when running on openshift
+      hostPID: {{ (quote .Values.runtime.agent.hostPID | empty) | ternary $openshiftEnabled .Values.runtime.agent.hostPID }}
       initContainers:
 {{ include "rad-plugins.bootstrap-initcontainer" . | indent 8 }}
       containers:
@@ -63,18 +65,20 @@ spec:
             - name: HOST_ROOT
               value: /host
             {{- with .Values.runtime.agent.collectors }}
-            - name: TRACER_COLLECTOR_DOCKER_ENABLED
-              value: {{ .docker.enabled | quote }}
-            {{- if .docker.enabled }}
-            - name: TRACER_COLLECTOR_DOCKER_SOCKET
-              value: {{ .docker.socket | quote }}
-            {{- end }}
+            # containerd is enabled by default unless running on OpenShift.
             - name: TRACER_COLLECTOR_CONTAINERD_ENABLED
-              value: {{ .containerd.enabled | quote }}
-            {{- if .containerd.enabled }}
+              value: {{ (quote .containerd.enabled | empty) | ternary (not $openshiftEnabled) .containerd.enabled | quote }}
             - name: TRACER_COLLECTOR_CONTAINERD_SOCKET
               value: {{ .containerd.socket | quote }}
-            {{- end }}
+            # crio is enabled by default when running on OpenShift.
+            - name: TRACER_COLLECTOR_CRIO_ENABLED
+              value: {{ (quote .crio.enabled | empty) | ternary $openshiftEnabled .crio.enabled | quote}}
+            - name: TRACER_COLLECTOR_CRIO_SOCKET
+              value: {{ .crio.socket | quote }}
+            - name: TRACER_COLLECTOR_DOCKER_ENABLED
+              value: {{ .docker.enabled | quote }}
+            - name: TRACER_COLLECTOR_DOCKER_SOCKET
+              value: {{ .docker.socket | quote }}
             {{- if .runtimePath }}
             - name: RUNTIME_PATH
               value: {{ .runtimePath | quote }}
@@ -220,7 +224,6 @@ spec:
         {{- end }}
       restartPolicy: Always
       automountServiceAccountToken: false
-      serviceAccount: rad-runtime
       serviceAccountName: rad-runtime
       terminationGracePeriodSeconds: 30
       tolerations:

--- a/stable/rad-plugins/templates/runtime/rbac.yaml
+++ b/stable/rad-plugins/templates/runtime/rbac.yaml
@@ -57,17 +57,17 @@ metadata:
     app_version: {{ .Values.runtime.image.tag | quote }}
     maintained_by: rad.security
 rules:
-  - apiGroups: [""]
-    resources: ["pods"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "deployments", "replicasets", "statefulsets", "jobs", "cronjobs"]
+    verbs: ["get", "watch", "list"]
+
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
     verbs: ["get", "watch", "list"]
 
   - apiGroups: [""]
-    resources: ["services"]
-    verbs: ["get", "watch", "list"]
-
-  - apiGroups: [ "" ]
-    resources: [ "nodes" ]
-    verbs: [ "get", "watch", "list" ]
+    resources: ["configmaps", "pods", "nodes", "services"]
+    verbs: ["get", "watch", "list" ]
 
 ---
 

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -187,10 +187,11 @@ runtime:
     tag: v0.1.1
   agent:
     env:
-      AGENT_LOG_LEVEL: INFO
-      AGENT_TRACER_IGNORE_NAMESPACES: |
+      LOG_LEVEL: INFO
+      TRACER_IGNORE_NAMESPACES: |
         cert-manager,
         rad,
+        ksoc,
         kube-node-lease,
         kube-public,
         kube-system
@@ -228,7 +229,7 @@ runtime:
     grpcServerBatchSize: 2000
   exporter:
     env:
-      EXPORTER_LOG_LEVEL: INFO
+      LOG_LEVEL: INFO
 
     # -- Allows to specify wildcard rules for filtering command arguments.
     execFilters: []

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -184,7 +184,7 @@ runtime:
   reachableVulnerabilitiesEnabled: true
   image:
     repository: public.ecr.aws/n8h5y2v5/rad-security/rad-runtime
-    tag: v0.1.0
+    tag: v0.1.1
   agent:
     env:
       AGENT_LOG_LEVEL: INFO

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -184,7 +184,7 @@ runtime:
   reachableVulnerabilitiesEnabled: true
   image:
     repository: public.ecr.aws/n8h5y2v5/rad-security/rad-runtime
-    tag: v0.1.1
+    tag: v0.1.2
   agent:
     env:
       LOG_LEVEL: INFO

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -203,16 +203,22 @@ runtime:
         cpu: 100m
         memory: 128Mi
         ephemeral-storage: 100Mi
-    hostPID: false
+    # Disabled by default unless running on OpenShift.
+    hostPID: null
     collectors:
       # An absolute path to the runc binary executable.
       runtimePath: ""
+      containerd:
+        # Enabled by default unless running on OpenShift.
+        enabled: null
+        socket: /run/containerd/containerd.sock
+      crio:
+        # Enabled by default when running on OpenShift.
+        enabled: null
+        socket: /run/crio/crio.sock
       docker:
         enabled: false
         socket: /run/docker.sock
-      containerd:
-        enabled: true
-        socket: /run/containerd/containerd.sock
     mounts:
       # A list of volumes you want to add to the agent pods.
       volumes: []
@@ -248,7 +254,7 @@ runtime:
       maxSurge: 0
   serviceAccountAnnotations: {}
 
-# Toggles support for Openshift. Please note that functionality is limited at the moment.
+# Enables support for OpenShift.
 openshift:
   enabled: false
 


### PR DESCRIPTION
#### What this PR does / why we need it
To add possibility to run rad-plugins on openshift platform

#### Special notes for your reviewer
PR is based on: https://github.com/ksoclabs/ksoc-plugins-helm-chart/pull/206

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
