### PR TITLE
Update Images And Break up Agent Image Into Seperate Images

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.1.9
+version: 2.1.10
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://rad.security/hs-fs/hubfs/Supplementary%20COMBO@2x.png?width=655&height=229&name=Supplementary%20COMBO@2x.png
@@ -18,7 +18,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: added
-      description: Bump dependencies.
+      description: Updated images to use new build system.
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -442,7 +442,7 @@ The command removes all the Kubernetes components associated with the chart and 
 |-----|------|---------|-------------|
 | bootstrapper.env | object | `{}` |  |
 | bootstrapper.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-bootstrapper"` | The image to use for the rad-bootstrapper deployment |
-| bootstrapper.image.tag | string | `"v1.1.11"` |  |
+| bootstrapper.image.tag | string | `"v1.1.13"` |  |
 | bootstrapper.nodeSelector | object | `{}` |  |
 | bootstrapper.podAnnotations | object | `{}` |  |
 | bootstrapper.resources.limits.cpu | string | `"100m"` |  |
@@ -459,7 +459,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | guard.config.LOG_LEVEL | string | `"info"` | The log level to use. |
 | guard.enabled | bool | `true` |  |
 | guard.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-guard"` | The image to use for the rad-guard deployment |
-| guard.image.tag | string | `"v1.1.17"` |  |
+| guard.image.tag | string | `"v1.1.19"` |  |
 | guard.nodeSelector | object | `{}` |  |
 | guard.podAnnotations | object | `{}` |  |
 | guard.replicas | int | `1` |  |
@@ -500,6 +500,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | runtime.agent.eventQueueSize | int | `20000` |  |
 | runtime.agent.grpcServerBatchSize | int | `2000` |  |
 | runtime.agent.hostPID | string | `nil` |  |
+| runtime.agent.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-runtime"` |  |
+| runtime.agent.image.tag | string | `"v0.1.13"` |  |
 | runtime.agent.mounts.volumeMounts | list | `[]` |  |
 | runtime.agent.mounts.volumes | list | `[]` |  |
 | runtime.agent.resources.limits.cpu | string | `"200m"` |  |
@@ -511,14 +513,14 @@ The command removes all the Kubernetes components associated with the chart and 
 | runtime.enabled | bool | `false` |  |
 | runtime.exporter.env.LOG_LEVEL | string | `"INFO"` |  |
 | runtime.exporter.execFilters | list | `[]` | Allows to specify wildcard rules for filtering command arguments. |
+| runtime.exporter.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-runtime-exporter"` |  |
+| runtime.exporter.image.tag | string | `"v0.1.13"` |  |
 | runtime.exporter.resources.limits.cpu | string | `"500m"` |  |
 | runtime.exporter.resources.limits.ephemeral-storage | string | `"1Gi"` |  |
 | runtime.exporter.resources.limits.memory | string | `"1Gi"` |  |
 | runtime.exporter.resources.requests.cpu | string | `"100m"` |  |
 | runtime.exporter.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | runtime.exporter.resources.requests.memory | string | `"128Mi"` |  |
-| runtime.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-runtime"` |  |
-| runtime.image.tag | string | `"v0.1.5"` |  |
 | runtime.nodeName | string | `""` |  |
 | runtime.nodeSelector | object | `{}` |  |
 | runtime.reachableVulnerabilitiesEnabled | bool | `true` |  |
@@ -535,7 +537,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | sbom.env.SBOM_CHECK_LATEST | bool | `false` | Experimental: Whether to check for the latest image in the container registry and generate SBOM for it. If deployed image has tag with semver format, rad-sbom tries to get the newest image, newest minor version, or newest patch version. If the tag is not in semver format, rad-sbom tries to get the newest image from the container registry based on the tag time. Please be aware that time-based algorithm requires many requests to the container registry and may be slow. It works only if credentials are provided. Please note that this feature is experimental and may not work with all container registries. |
 | sbom.env.SBOM_FORMAT | string | `"cyclonedx-json"` | The format of the generated SBOM. Currently we support: syft-json,cyclonedx-json,spdx-json |
 | sbom.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-sbom"` | The image to use for the rad-sbom deployment |
-| sbom.image.tag | string | `"v1.1.34"` |  |
+| sbom.image.tag | string | `"v1.1.36"` |  |
 | sbom.nodeSelector | object | `{}` |  |
 | sbom.podAnnotations | object | `{}` |  |
 | sbom.resources.limits.cpu | string | `"1000m"` |  |
@@ -550,7 +552,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | sync.enabled | bool | `true` |  |
 | sync.env | object | `{}` |  |
 | sync.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-sync"` | The image to use for the rad-sync deployment |
-| sync.image.tag | string | `"v1.1.15"` |  |
+| sync.image.tag | string | `"v1.1.17"` |  |
 | sync.nodeSelector | object | `{}` |  |
 | sync.podAnnotations | object | `{}` |  |
 | sync.resources.limits.cpu | string | `"200m"` |  |
@@ -565,7 +567,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | watch.enabled | bool | `true` |  |
 | watch.env.RECONCILIATION_AT_START | bool | `false` | Whether to trigger reconciliation at startup. |
 | watch.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-watch"` | The image to use for the rad-watch deployment |
-| watch.image.tag | string | `"v1.1.25"` |  |
+| watch.image.tag | string | `"v1.1.27"` |  |
 | watch.ingestCustomResources | bool | `false` | If set will allow ingesting Custom Resources specified in `customResourceRules` |
 | watch.nodeSelector | object | `{}` |  |
 | watch.podAnnotations | object | `{}` |  |

--- a/stable/rad-plugins/templates/runtime/daemonset.yaml
+++ b/stable/rad-plugins/templates/runtime/daemonset.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app_name: rad-runtime
-    app_version: {{ .Values.runtime.image.tag | quote }}
+    app_version: {{ .Values.runtime.agent.image.tag | quote }}
     maintained_by: rad.security
 spec:
   selector:
@@ -35,7 +35,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app_name: rad-runtime
-        app_version: {{ .Values.runtime.image.tag | quote }}
+        app_version: {{ .Values.runtime.agent.image.tag | quote }}
         maintained_by: rad.security
     spec:
       {{- if .Values.workloads.imagePullSecretName }}
@@ -47,11 +47,9 @@ spec:
       initContainers:
 {{ include "rad-plugins.bootstrap-initcontainer" . | indent 8 }}
       containers:
-        - command:
-            - micro-agent
           env:
             - name: AGENT_VERSION
-              value: {{ .Values.runtime.image.tag | quote }}
+              value: {{ .Values.runtime.agent.image.tag | quote }}
             - name: CHART_VERSION
               value: {{ .Chart.Version }}
             - name: API_URL
@@ -113,7 +111,7 @@ spec:
             - name: "{{ $key }}"
               value: "{{ $value }}"
             {{- end }}
-          image: {{ .Values.runtime.image.repository }}:{{ .Values.runtime.image.tag }}
+          image: {{ .Values.runtime.agent.image.repository }}:{{ .Values.runtime.agent.image.tag }}
           imagePullPolicy: Always
           name: agent
           ports:
@@ -173,11 +171,9 @@ spec:
             {{- with .Values.runtime.agent.mounts.volumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-        - command:
-            - micro-exporter
           env:
             - name: AGENT_VERSION
-              value: {{ .Values.runtime.image.tag | quote }}
+              value: {{ .Values.runtime.agent.image.tag | quote }}
             - name: CHART_VERSION
               value: {{ .Chart.Version }}
             - name: API_URL
@@ -203,7 +199,7 @@ spec:
             - name: "{{ $key }}"
               value: "{{ $value }}"
             {{- end }}
-          image: {{ .Values.runtime.image.repository }}:{{ .Values.runtime.image.tag }}
+          image: {{ .Values.runtime.exporter.image.repository }}:{{ .Values.runtime.exporter.image.tag }}
           imagePullPolicy: Always
           name: exporter
           ports:

--- a/stable/rad-plugins/templates/runtime/dynamic-config.yaml
+++ b/stable/rad-plugins/templates/runtime/dynamic-config.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app_name: rad-runtime
-    app_version: {{ .Values.runtime.image.tag | quote }}
+    app_version: {{ .Values.runtime.agent.image.tag | quote }}
     maintained_by: rad.security
 data:
 # Placeholder for dynamic configuration
@@ -19,7 +19,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app_name: rad-runtime
-    app_version: {{ .Values.runtime.image.tag | quote }}
+    app_version: {{ .Values.runtime.agent.image.tag | quote }}
     maintained_by: rad.security
 data:
 # Placeholder for dynamic configuration

--- a/stable/rad-plugins/templates/runtime/rbac.yaml
+++ b/stable/rad-plugins/templates/runtime/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app_name: rad-runtime
-    app_version: {{ .Values.runtime.image.tag | quote }}
+    app_version: {{ .Values.runtime.agent.image.tag | quote }}
     maintained_by: rad.security
   {{- with .Values.runtime.serviceAccountAnnotations }}
   annotations:
@@ -23,7 +23,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app_name: rad-runtime
-    app_version: {{ .Values.runtime.image.tag | quote }}
+    app_version: {{ .Values.runtime.agent.image.tag | quote }}
     maintained_by: rad.security
 rules:
   - apiGroups: [""]
@@ -40,7 +40,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app_name: rad-runtime
-    app_version: {{ .Values.runtime.image.tag | quote }}
+    app_version: {{ .Values.runtime.agent.image.tag | quote }}
     maintained_by: rad.security
   annotations:
     kubernetes.io/service-account.name: rad-runtime
@@ -54,7 +54,7 @@ metadata:
   name: rad-runtime
   labels:
     app_name: rad-runtime
-    app_version: {{ .Values.runtime.image.tag | quote }}
+    app_version: {{ .Values.runtime.agent.image.tag | quote }}
     maintained_by: rad.security
 rules:
   - apiGroups: ["apps"]
@@ -77,7 +77,7 @@ metadata:
   name: rad-runtime
   labels:
     app_name: rad-runtime
-    app_version: {{ .Values.runtime.image.tag | quote }}
+    app_version: {{ .Values.runtime.agent.image.tag | quote }}
     maintained_by: rad.security
 roleRef:
   kind: ClusterRole
@@ -118,7 +118,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app_name: rad-runtime
-    app_version: {{ .Values.runtime.image.tag | quote }}
+    app_version: {{ .Values.runtime.agent.image.tag | quote }}
     maintained_by: rad.security
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -37,7 +37,7 @@ bootstrapper:
   image:
     # -- The image to use for the rad-bootstrapper deployment
     repository: public.ecr.aws/n8h5y2v5/rad-security/rad-bootstrapper
-    tag: v1.1.11
+    tag: v1.1.13
   env: {}
   resources:
     limits:
@@ -57,7 +57,7 @@ guard:
   image:
     # -- The image to use for the rad-guard deployment
     repository: public.ecr.aws/n8h5y2v5/rad-security/rad-guard
-    tag: v1.1.17
+    tag: v1.1.19
   config:
     # -- Whether to block on error.
     BLOCK_ON_ERROR: false
@@ -92,7 +92,7 @@ sbom:
   image:
     # -- The image to use for the rad-sbom deployment
     repository: public.ecr.aws/n8h5y2v5/rad-security/rad-sbom
-    tag: v1.1.34
+    tag: v1.1.36
   env:
     # -- Whether to mutate the image in pod spec by adding digest at the end. By default, digests are added to images to ensure
     # that the image that runs in the cluster matches the digest of the build.  Disable this if your continuous deployment
@@ -138,7 +138,7 @@ sync:
   image:
     # -- The image to use for the rad-sync deployment
     repository: public.ecr.aws/n8h5y2v5/rad-security/rad-sync
-    tag: v1.1.15
+    tag: v1.1.17
   env: {}
   resources:
     limits:
@@ -159,7 +159,7 @@ watch:
   image:
     # -- The image to use for the rad-watch deployment
     repository: public.ecr.aws/n8h5y2v5/rad-security/rad-watch
-    tag: v1.1.25
+    tag: v1.1.27
   env:
     # -- Whether to trigger reconciliation at startup.
     RECONCILIATION_AT_START: false
@@ -193,9 +193,6 @@ watch:
 runtime:
   enabled: false
   reachableVulnerabilitiesEnabled: true
-  image:
-    repository: public.ecr.aws/n8h5y2v5/rad-security/rad-runtime
-    tag: v0.1.5
   agent:
     env:
       LOG_LEVEL: INFO
@@ -206,6 +203,9 @@ runtime:
         kube-node-lease,
         kube-public,
         kube-system
+    image:
+      repository: public.ecr.aws/n8h5y2v5/rad-security/rad-runtime
+      tag: v0.1.13
     resources:
       limits:
         cpu: 200m
@@ -241,6 +241,10 @@ runtime:
   exporter:
     env:
       LOG_LEVEL: INFO
+
+    image:
+      repository: public.ecr.aws/n8h5y2v5/rad-security/rad-runtime-exporter
+      tag: v0.1.13
 
     # -- Allows to specify wildcard rules for filtering command arguments.
     execFilters: []


### PR DESCRIPTION
Updates our images to use the newest way of building images, and separates out the agent image into two different configurable images. 


<!--
Thank you for contributing to rad-security/plugins-helm-chart.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#### Special notes for your reviewer

#### Checklist

- [X] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [X] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [X] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
