### PR TITLE
Fix typo in agent configuration

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.1.10
+version: 2.1.11
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://rad.security/hs-fs/hubfs/Supplementary%20COMBO@2x.png?width=655&height=229&name=Supplementary%20COMBO@2x.png
@@ -17,8 +17,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: added
-      description: Updated images to use new build system.
+    - kind: fixed
+      description: Formatting container configuration in agent.
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/templates/runtime/daemonset.yaml
+++ b/stable/rad-plugins/templates/runtime/daemonset.yaml
@@ -47,7 +47,7 @@ spec:
       initContainers:
 {{ include "rad-plugins.bootstrap-initcontainer" . | indent 8 }}
       containers:
-          env:
+        - env:
             - name: AGENT_VERSION
               value: {{ .Values.runtime.agent.image.tag | quote }}
             - name: CHART_VERSION
@@ -171,7 +171,7 @@ spec:
             {{- with .Values.runtime.agent.mounts.volumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-          env:
+        - env:
             - name: AGENT_VERSION
               value: {{ .Values.runtime.agent.image.tag | quote }}
             - name: CHART_VERSION


### PR DESCRIPTION
I made a small typo in the last PR. When I removed the command field, I also removed the `-`. This resulted in an invalid Daemonset spec. 

Running the rendered Daemonset with `--dry-run=server` now results in the following:
```
Warning: resource daemonsets/rad-runtime is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
daemonset.apps/rad-runtime configured (server dry run)
```
<!--
Thank you for contributing to rad-security/plugins-helm-chart.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#### Special notes for your reviewer

#### Checklist

- [X] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [X] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [X] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
