### PR TITLE
Add experimental Runtime HTTP tracing and PII detection

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.1.11
+version: 2.2.0
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://rad.security/hs-fs/hubfs/Supplementary%20COMBO@2x.png?width=655&height=229&name=Supplementary%20COMBO@2x.png
@@ -17,8 +17,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Formatting container configuration in agent.
+    - kind: added
+      description: Added experimental support for Runtime HTTP Tracing and PII detection
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -501,7 +501,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | runtime.agent.grpcServerBatchSize | int | `2000` |  |
 | runtime.agent.hostPID | string | `nil` |  |
 | runtime.agent.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-runtime"` |  |
-| runtime.agent.image.tag | string | `"v0.1.13"` |  |
+| runtime.agent.image.tag | string | `"v0.1.15"` |  |
 | runtime.agent.mounts.volumeMounts | list | `[]` |  |
 | runtime.agent.mounts.volumes | list | `[]` |  |
 | runtime.agent.resources.limits.cpu | string | `"200m"` |  |
@@ -514,15 +514,24 @@ The command removes all the Kubernetes components associated with the chart and 
 | runtime.exporter.env.LOG_LEVEL | string | `"INFO"` |  |
 | runtime.exporter.execFilters | list | `[]` | Allows to specify wildcard rules for filtering command arguments. |
 | runtime.exporter.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-runtime-exporter"` |  |
-| runtime.exporter.image.tag | string | `"v0.1.13"` |  |
+| runtime.exporter.image.tag | string | `"v0.1.15"` |  |
 | runtime.exporter.resources.limits.cpu | string | `"500m"` |  |
 | runtime.exporter.resources.limits.ephemeral-storage | string | `"1Gi"` |  |
 | runtime.exporter.resources.limits.memory | string | `"1Gi"` |  |
 | runtime.exporter.resources.requests.cpu | string | `"100m"` |  |
 | runtime.exporter.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | runtime.exporter.resources.requests.memory | string | `"128Mi"` |  |
+| runtime.httpTracingEnabled | bool | `false` |  |
 | runtime.nodeName | string | `""` |  |
 | runtime.nodeSelector | object | `{}` |  |
+| runtime.piiAnalyzer.enabled | bool | `false` |  |
+| runtime.piiAnalyzer.image.repository | string | `"mcr.microsoft.com/presidio-analyzer"` |  |
+| runtime.piiAnalyzer.image.tag | string | `"2.2.4"` |  |
+| runtime.piiAnalyzer.replicas | int | `1` |  |
+| runtime.piiAnalyzer.resources.limits.cpu | string | `"1000m"` |  |
+| runtime.piiAnalyzer.resources.limits.memory | string | `"2Gi"` |  |
+| runtime.piiAnalyzer.resources.requests.cpu | string | `"100m"` |  |
+| runtime.piiAnalyzer.resources.requests.memory | string | `"128Mi"` |  |
 | runtime.reachableVulnerabilitiesEnabled | bool | `true` |  |
 | runtime.serviceAccountAnnotations | object | `{}` |  |
 | runtime.tolerations | list | `[]` |  |

--- a/stable/rad-plugins/templates/runtime/daemonset.yaml
+++ b/stable/rad-plugins/templates/runtime/daemonset.yaml
@@ -106,7 +106,7 @@ spec:
             - name: TRACER_HTTP_PII_DETECTOR_PRESIDIO_ENABLED
               value: "true"
             - name: TRACER_HTTP_PII_DETECTOR_PRESIDIO_URL
-              value: "http://rad-pii-analyzer.rad.svc.cluster.local"
+              value: "http://rad-pii-analyzer.{{ .Release.Namespace }}.svc.cluster.local"
             {{- end }}
             {{- end }}
             {{- if .Values.runtime.agent.httpTracingEnabled }}

--- a/stable/rad-plugins/templates/runtime/daemonset.yaml
+++ b/stable/rad-plugins/templates/runtime/daemonset.yaml
@@ -99,6 +99,18 @@ spec:
             - name: TRACER_OPEN_PREFIXES
               value: "/lib,/lib64,/usr,/bin,/sbin"
             {{- end }}
+            {{- if .Values.runtime.httpTracingEnabled }}
+            - name: TRACER_HTTP_ENABLED
+              value: "true"
+            {{- if and .Values.runtime.piiAnalyzer .Values.runtime.piiAnalyzer.enabled }}
+            - name: TRACER_HTTP_PII_DETECTOR_PRESIDIO_ENABLED
+              value: "true"
+            - name: TRACER_HTTP_PII_DETECTOR_PRESIDIO_URL
+              value: "http://rad-pii-analyzer.rad.svc.cluster.local"
+            {{- end }}
+            {{- end }}
+            {{- if .Values.runtime.agent.httpTracingEnabled }}
+            {{- end }}
             {{- if .Values.runtime.agent.eventQueueSize }}
             - name: EVENT_QUEUE_SIZE
               value: {{ .Values.runtime.agent.eventQueueSize | quote }}

--- a/stable/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml
+++ b/stable/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml
@@ -1,0 +1,57 @@
+{{- if and .Values.runtime .Values.runtime.enabled -}}
+{{- if .Values.runtime.httpTracingEnabled }}
+{{- if and .Values.runtime.piiAnalyzer .Values.runtime.piiAnalyzer.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rad-pii-analyzer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: rad-pii-analyzer
+spec:
+  replicas: {{ .Values.runtime.piiAnalyzer.replicas }}
+  selector:
+    matchLabels:
+      app: rad-pii-analyzer
+  template:
+    metadata:
+      labels:
+        app: rad-pii-analyzer
+        app_version: {{ .Values.runtime.piiAnalyzer.image.tag | quote }}
+    spec:
+      containers:
+      - name: rad-pii-analyzer
+        image: {{ .Values.runtime.piiAnalyzer.image.repository }}:{{ .Values.runtime.piiAnalyzer.image.tag }}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            memory: {{ .Values.runtime.piiAnalyzer.resources.requests.memory }}
+            cpu: {{ .Values.runtime.piiAnalyzer.resources.requests.cpu }}
+          limits:
+            memory: {{ .Values.runtime.piiAnalyzer.resources.limits.memory }}
+            cpu: {{ .Values.runtime.piiAnalyzer.resources.limits.cpu }}
+        env:
+          - name: PORT
+            value: "8080"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rad-pii-analyzer
+  namespace: rad
+  labels:
+    app: rad-pii-analyzer
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: rad-pii-analyzer
+  selector:
+    app: rad-pii-analyzer
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -193,6 +193,7 @@ watch:
 runtime:
   enabled: false
   reachableVulnerabilitiesEnabled: true
+  httpTracingEnabled: false
   agent:
     env:
       LOG_LEVEL: INFO
@@ -205,7 +206,7 @@ runtime:
         kube-system
     image:
       repository: public.ecr.aws/n8h5y2v5/rad-security/rad-runtime
-      tag: v0.1.13
+      tag: v0.1.15
     resources:
       limits:
         cpu: 200m
@@ -244,7 +245,7 @@ runtime:
 
     image:
       repository: public.ecr.aws/n8h5y2v5/rad-security/rad-runtime-exporter
-      tag: v0.1.13
+      tag: v0.1.15
 
     # -- Allows to specify wildcard rules for filtering command arguments.
     execFilters: []
@@ -258,6 +259,20 @@ runtime:
         cpu: 100m
         memory: 128Mi
         ephemeral-storage: 100Mi
+  piiAnalyzer:
+    enabled: false
+    image:
+      repository: mcr.microsoft.com/presidio-analyzer
+      tag: 2.2.4
+    replicas: 1
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 2Gi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
   nodeSelector: {}
   nodeName: ""
   tolerations: []


### PR DESCRIPTION
#### What this PR does / why we need it

This adds experimental support for Runtime HTTP tracing and PII detection using Microsoft Presidio.

It's disabled by default.

<!--
Thank you for contributing to rad-security/plugins-helm-chart.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

-->

<!-- markdownlint-disable-next-line first-line-heading -->

#### Special notes for your reviewer

#### Checklist

- [X] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [X] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [X] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
