### PR TITLE
Simplify experimental PII detection config

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.2.1
+version: 2.2.2
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://rad.security/hs-fs/hubfs/Supplementary%20COMBO@2x.png?width=655&height=229&name=Supplementary%20COMBO@2x.png
@@ -17,8 +17,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fixed config for experimental PII detection
+    - kind: changed
+      description: Simplified config for experimental PII detection
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -389,6 +389,17 @@ runtime:
     - wildcard: "secret=(*)"
 ```
 
+## Experimental PII detection
+The runtime plugin has an experimental feature to detect PII in http requests. This feature is disabled by default and can be enabled by setting the following values in the `values.yaml` file:
+
+```yaml
+runtime:
+  enabled: true
+  httpTracingEnabled: true
+  piiAnalyzer:
+    enabled: true
+```
+
 ## Upgrading the Chart
 
 Typically, we advise maintaining the most current versions of plugins. However, our [RAD Security](https://rad.security) plugins are designed to support upgrades between any two versions, with certain exceptions as outlined in our Helm chart changelog which you can access [here](https://artifacthub.io/packages/helm/rad/rad-plugins?modal=changelog).

--- a/stable/rad-plugins/README.md.gotmpl
+++ b/stable/rad-plugins/README.md.gotmpl
@@ -389,6 +389,17 @@ runtime:
     - wildcard: "secret=(*)"
 ```
 
+## Experimental PII detection
+The runtime plugin has an experimental feature to detect PII in http requests. This feature is disabled by default and can be enabled by setting the following values in the `values.yaml` file:
+
+```yaml
+runtime:
+  enabled: true
+  httpTracingEnabled: true
+  piiAnalyzer:
+    enabled: true
+```
+
 ## Upgrading the Chart
 
 Typically, we advise maintaining the most current versions of plugins. However, our [RAD Security](https://rad.security) plugins are designed to support upgrades between any two versions, with certain exceptions as outlined in our Helm chart changelog which you can access [here](https://artifacthub.io/packages/helm/rad/rad-plugins?modal=changelog).

--- a/stable/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml
+++ b/stable/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: rad-pii-analyzer
 spec:
-  replicas: {{ .Values.runtime.piiAnalyzer.replicas }}
+  replicas: {{ default 1 .Values.runtime.piiAnalyzer.replicas }}
   selector:
     matchLabels:
       app: rad-pii-analyzer
@@ -17,21 +17,39 @@ spec:
     metadata:
       labels:
         app: rad-pii-analyzer
-        app_version: {{ .Values.runtime.piiAnalyzer.image.tag | quote }}
+{{- if and .Values.runtime .Values.runtime.piiAnalyzer .Values.runtime.piiAnalyzer.image .Values.runtime.piiAnalyzer.image.tag }}
+        app_version: {{ default "2.2.4" .Values.runtime.piiAnalyzer.image.tag | quote }}
+{{- else }}
+        app_version: "2.2.4"
+{{- end }}
     spec:
       containers:
       - name: rad-pii-analyzer
-        image: {{ .Values.runtime.piiAnalyzer.image.repository }}:{{ .Values.runtime.piiAnalyzer.image.tag }}
+{{- if and .Values.runtime .Values.runtime.piiAnalyzer .Values.runtime.piiAnalyzer.image }}
+        image: {{ default "mcr.microsoft.com/presidio-analyzer" .Values.runtime.piiAnalyzer.image.repository }}:{{ default "2.2.4" .Values.runtime.piiAnalyzer.image.tag }}
+{{- else }}
+        image: mcr.microsoft.com/presidio-analyzer:2.2.4
+{{- end }}
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
+{{- if and .Values.runtime .Values.runtime.piiAnalyzer .Values.runtime.piiAnalyzer.resources }}
         resources:
           requests:
-            memory: {{ .Values.runtime.piiAnalyzer.resources.requests.memory }}
-            cpu: {{ .Values.runtime.piiAnalyzer.resources.requests.cpu }}
+            memory: {{ default "128Mi" .Values.runtime.piiAnalyzer.resources.requests.memory }}
+            cpu: {{ default "100m" .Values.runtime.piiAnalyzer.resources.requests.cpu }}
           limits:
-            memory: {{ .Values.runtime.piiAnalyzer.resources.limits.memory }}
-            cpu: {{ .Values.runtime.piiAnalyzer.resources.limits.cpu }}
+            memory: {{ default "2Gi" .Values.runtime.piiAnalyzer.resources.limits.memory }}
+            cpu: {{ default "1000m" .Values.runtime.piiAnalyzer.resources.limits.cpu }}
+{{- else }}
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "2Gi"
+            cpu: "1000m"
+{{- end }}
         env:
           - name: PORT
             value: "8080"


### PR DESCRIPTION
#### What this PR does / why we need it
Simplify the PII detection config so that the underlying model can be overridden, but doesn't need to be specified by the user.  With this change, to enable PII detection, only the following values need to be set in `values.yaml`:
```
runtime:
  enabled: true
  httpTracingEnabled: true
  piiAnalyzer:
    enabled: true
```

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
