### PR TITLE
Propagate runtime nodeSelectors to piiAnalyzer

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.2.2
+version: 2.2.3
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://rad.security/hs-fs/hubfs/Supplementary%20COMBO@2x.png?width=655&height=229&name=Supplementary%20COMBO@2x.png
@@ -18,7 +18,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: Simplified config for experimental PII detection
+      description: Propagated the runtime nodeSelector to the piiAnalyzer deployment.
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml
+++ b/stable/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml
@@ -53,6 +53,10 @@ spec:
         env:
           - name: PORT
             value: "8080"
+{{- with .Values.runtime.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
#### What this PR does / why we need it
Propagate the nodeSelectors specified in the runtime section of values.yaml to the experimental pii-analyzer deployment.  With this set:
```
nodeSelector:
  foo: bar
```
the following deployment is generated:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: rad-pii-analyzer
  namespace: ksoc
  labels:
    app: rad-pii-analyzer
spec:
  replicas: 1
  selector:
    matchLabels:
      app: rad-pii-analyzer
  template:
    metadata:
      labels:
        app: rad-pii-analyzer
        app_version: "2.2.4"
    spec:
      containers:
      - name: rad-pii-analyzer
        image: mcr.microsoft.com/presidio-analyzer:2.2.4
        imagePullPolicy: Always
        ports:
        - containerPort: 8080
        resources:
          requests:
            memory: "128Mi"
            cpu: "100m"
          limits:
            memory: "2Gi"
            cpu: "1000m"
        env:
          - name: PORT
            value: "8080"
      nodeSelector:
        foo: bar
```

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
