### PR TITLE
Add missing values for piiAnalyzer. Update rolling update for rad daemonset

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.2.4
+version: 2.2.5
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://rad.security/hs-fs/hubfs/Supplementary%20COMBO@2x.png?width=655&height=229&name=Supplementary%20COMBO@2x.png
@@ -18,7 +18,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: Separated the nodeSelector for the piiAnalyzer deployment.
+      description: Added missing default values for piiAnalyzer. Updated rolling update for runtime daemonset.
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -532,13 +532,25 @@ The command removes all the Kubernetes components associated with the chart and 
 | runtime.exporter.resources.requests.cpu | string | `"100m"` |  |
 | runtime.exporter.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | runtime.exporter.resources.requests.memory | string | `"128Mi"` |  |
+| runtime.httpTracingEnabled | bool | `false` |  |
 | runtime.nodeName | string | `""` |  |
 | runtime.nodeSelector | object | `{}` |  |
+| runtime.piiAnalyzer.enabled | bool | `false` |  |
+| runtime.piiAnalyzer.env.LOG_LEVEL | string | `"WARNING"` |  |
+| runtime.piiAnalyzer.image.repository | string | `"mcr.microsoft.com/presidio-analyzer"` |  |
+| runtime.piiAnalyzer.image.tag | string | `"2.2.357"` |  |
+| runtime.piiAnalyzer.nodeSelector | object | `{}` |  |
+| runtime.piiAnalyzer.replicas | int | `3` |  |
+| runtime.piiAnalyzer.resources.limits.cpu | string | `"1000m"` |  |
+| runtime.piiAnalyzer.resources.limits.memory | string | `"2Gi"` |  |
+| runtime.piiAnalyzer.resources.requests.cpu | string | `"100m"` |  |
+| runtime.piiAnalyzer.resources.requests.memory | string | `"128Mi"` |  |
+| runtime.piiAnalyzer.tolerations | list | `[]` |  |
 | runtime.reachableVulnerabilitiesEnabled | bool | `true` |  |
 | runtime.serviceAccountAnnotations | object | `{}` |  |
 | runtime.tolerations | list | `[]` |  |
 | runtime.updateStrategy.rollingUpdate.maxSurge | int | `0` | The maximum number of pods that can be scheduled above the desired number of pods. Can be an absolute number or percent, e.g. `5` or `"10%"` |
-| runtime.updateStrategy.rollingUpdate.maxUnavailable | int | `1` | The maximum number of pods that can be unavailable during the update. Can be an absolute number or percent, e.g.  `5` or `"10%"` |
+| runtime.updateStrategy.rollingUpdate.maxUnavailable | string | `"25%"` | The maximum number of pods that can be unavailable during the update. Can be an absolute number or percent, e.g.  `5` or `"10%"` |
 | runtime.updateStrategy.type | string | `"RollingUpdate"` |  |
 | sbom.enabled | bool | `true` |  |
 | sbom.env.IMAGE_PULL_SECRETS | string | `""` | Comma separated list of image pull secrets to use to pull container images. Important: The secrets must be created in the same namespace as the rad-sbom deployment. By default 'rad-sbom' tries to read imagePullSecrets from the manifest spec, but additionally, you can specify the secrets here. If you use AWS ECR private registry, we recommend to use EKS Pod Identity or IRSA to add access to "rad-sbom" to the ECR registry. |

--- a/stable/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml
+++ b/stable/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: rad-pii-analyzer
 spec:
-  replicas: {{ default 1 .Values.runtime.piiAnalyzer.replicas }}
+  replicas: {{ .Values.runtime.piiAnalyzer.replicas }}
   selector:
     matchLabels:
       app: rad-pii-analyzer
@@ -17,44 +17,34 @@ spec:
     metadata:
       labels:
         app: rad-pii-analyzer
-{{- if and .Values.runtime .Values.runtime.piiAnalyzer .Values.runtime.piiAnalyzer.image .Values.runtime.piiAnalyzer.image.tag }}
-        app_version: {{ default "2.2.4" .Values.runtime.piiAnalyzer.image.tag | quote }}
-{{- else }}
-        app_version: "2.2.4"
-{{- end }}
+        app_version: {{ .Values.runtime.piiAnalyzer.image.tag | quote }}
     spec:
       containers:
       - name: rad-pii-analyzer
-{{- if and .Values.runtime .Values.runtime.piiAnalyzer .Values.runtime.piiAnalyzer.image }}
-        image: {{ default "mcr.microsoft.com/presidio-analyzer" .Values.runtime.piiAnalyzer.image.repository }}:{{ default "2.2.4" .Values.runtime.piiAnalyzer.image.tag }}
-{{- else }}
-        image: mcr.microsoft.com/presidio-analyzer:2.2.4
-{{- end }}
+        image: {{ .Values.runtime.piiAnalyzer.image.repository }}:{{ .Values.runtime.piiAnalyzer.image.tag }}
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
-{{- if and .Values.runtime .Values.runtime.piiAnalyzer .Values.runtime.piiAnalyzer.resources }}
         resources:
           requests:
-            memory: {{ default "128Mi" .Values.runtime.piiAnalyzer.resources.requests.memory }}
-            cpu: {{ default "100m" .Values.runtime.piiAnalyzer.resources.requests.cpu }}
+            memory: {{ .Values.runtime.piiAnalyzer.resources.requests.memory }}
+            cpu: {{ .Values.runtime.piiAnalyzer.resources.requests.cpu }}
           limits:
-            memory: {{ default "2Gi" .Values.runtime.piiAnalyzer.resources.limits.memory }}
-            cpu: {{ default "1000m" .Values.runtime.piiAnalyzer.resources.limits.cpu }}
-{{- else }}
-        resources:
-          requests:
-            memory: "128Mi"
-            cpu: "100m"
-          limits:
-            memory: "2Gi"
-            cpu: "1000m"
-{{- end }}
+            memory: {{ .Values.runtime.piiAnalyzer.resources.limits.memory }}
+            cpu: {{ .Values.runtime.piiAnalyzer.resources.limits.cpu }}
         env:
           - name: PORT
             value: "8080"
+          {{- range $key, $value := .Values.runtime.piiAnalyzer.env }}
+          - name: "{{ $key }}"
+            value: "{{ $value }}"
+          {{- end }}
 {{- with .Values.runtime.piiAnalyzer.nodeSelector }}
       nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.runtime.piiAnalyzer.tolerations }}
+      tolerations:
 {{ toYaml . | indent 8 }}
 {{- end }}
 ---

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -193,6 +193,7 @@ watch:
 runtime:
   enabled: false
   reachableVulnerabilitiesEnabled: true
+  httpTracingEnabled: false
   agent:
     env:
       LOG_LEVEL: INFO
@@ -259,6 +260,24 @@ runtime:
         memory: 128Mi
         ephemeral-storage: 100Mi
 
+  piiAnalyzer:
+    enabled: false
+    env:
+      LOG_LEVEL: WARNING
+    image:
+      repository: mcr.microsoft.com/presidio-analyzer
+      tag: 2.2.357
+    nodeSelector: {}
+    replicas: 3
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 2Gi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    tolerations: []
+
   nodeSelector: {}
   nodeName: ""
   tolerations: []
@@ -266,7 +285,7 @@ runtime:
     type: RollingUpdate
     rollingUpdate:
       # -- The maximum number of pods that can be unavailable during the update. Can be an absolute number or percent, e.g.  `5` or `"10%"`
-      maxUnavailable: 1
+      maxUnavailable: "25%"
       # -- The maximum number of pods that can be scheduled above the desired number of pods. Can be an absolute number or percent, e.g. `5` or `"10%"`
       maxSurge: 0
   serviceAccountAnnotations: {}


### PR DESCRIPTION
#### What this PR does / why we need it
It adds missing values for `piiAnalyzer`. 

It also changes the default rolling update strategy for `runtime` daemonset.

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
