### PR TITLE
Add config to enable RBAC and non-RBAC resource separation in helm ops

### DIFF
--- a/.github/workflows/test-rbac-resources-separation.yaml
+++ b/.github/workflows/test-rbac-resources-separation.yaml
@@ -1,93 +1,39 @@
-name: checks
+name: Test RBAC/Resources Separation
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'stable/rad-plugins/**'
   pull_request:
-
-# Cancel any in-flight jobs for the same PR branch so there's only one active at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    branches: [ main ]
+    paths:
+      - 'stable/rad-plugins/**'
+  workflow_dispatch:
 
 jobs:
-  pre-commit:
-    permissions:
-      contents: read
+  test-separation:
     runs-on: ubuntu-latest
-    container: us.gcr.io/ksoc-public/kubernetes-toolkit:1.29.4
     steps:
-      - name: clone repo
-        uses: actions/checkout@v4
-      - name: pre-commit checks
-        run: pre-commit-checks
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-  deprecation-checks:
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    container: us.gcr.io/ksoc-public/kubernetes-toolkit:1.29.4
-    steps:
-      - name: clone repo
-        uses: actions/checkout@v4
-      - name: deprecation-checks
-        run: make deprecation-checks
-
-  kubeval-checks:
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    container: us.gcr.io/ksoc-public/kubernetes-toolkit:1.29.4
-    steps:
-      - name: clone repo
-        uses: actions/checkout@v4
-      - name: kubeval-checks
-        run: make kubeval-checks
-
-  lint:
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.14.2
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
-      - name: Run chart-testing (lint)
-        run: ct lint --config test/ct.yaml
-      - name: Run helm lint
-        run: helm lint stable/rad-plugins
+          version: v3.11.2
 
-  rbac-resources-separation:
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.14.2
-      - name: Test RBAC/Resources Separation
+      - name: Create test directories
         run: |
-          # Create test directories
           mkdir -p test-output-{default,no-rbac,no-resources,pii,pii-no-rbac,pii-no-resources}
 
-          # Test default (both RBAC and resources)
+      - name: Test default (both RBAC and resources)
+        run: |
           helm template stable/rad-plugins \
             --set runtime.enabled=true \
-            --set runtime.httpTracingEnabled=true \
-            --set runtime.piiAnalyzer.enabled=true \
             --output-dir test-output-default
           echo "Default configuration file count: $(find test-output-default -type f | wc -l)"
+          # Verify both RBAC and non-RBAC resources
           if ! grep -q "kind: ClusterRole\|kind: Role\|kind: RoleBinding\|kind: ClusterRoleBinding\|kind: ServiceAccount" test-output-default/rad-plugins/templates/rbac.yaml; then
             echo "❌ Default configuration missing RBAC resources"
             exit 1
@@ -98,48 +44,57 @@ jobs:
           fi
           echo "✅ Default configuration test passed"
 
-          # Test no RBAC
+      - name: Test no RBAC
+        run: |
           helm template stable/rad-plugins \
             --set runtime.enabled=true \
             --set rad.deployment.rbac=false \
             --output-dir test-output-no-rbac
           echo "No RBAC configuration file count: $(find test-output-no-rbac -type f | wc -l)"
+          # Verify RBAC resources are not present
           if [ -f test-output-no-rbac/rad-plugins/templates/rbac.yaml ]; then
             echo "❌ No RBAC configuration still has RBAC resources"
             exit 1
           fi
+          # Verify non-RBAC resources are present
           if ! grep -q "kind: Deployment" test-output-no-rbac/rad-plugins/templates/guard/deployment.yaml; then
             echo "❌ No RBAC configuration missing non-RBAC resources"
             exit 1
           fi
           echo "✅ No RBAC configuration test passed"
 
-          # Test no resources
+      - name: Test no resources
+        run: |
           helm template stable/rad-plugins \
             --set runtime.enabled=true \
             --set rad.deployment.resources=false \
             --output-dir test-output-no-resources
           echo "No resources configuration file count: $(find test-output-no-resources -type f | wc -l)"
+          # Verify RBAC resources are present
           if ! grep -q "kind: ClusterRole\|kind: Role\|kind: RoleBinding\|kind: ClusterRoleBinding\|kind: ServiceAccount" test-output-no-resources/rad-plugins/templates/rbac.yaml; then
             echo "❌ No resources configuration missing RBAC resources"
             exit 1
           fi
+          # Verify non-RBAC resources are not present
           if [ -f test-output-no-resources/rad-plugins/templates/guard/deployment.yaml ]; then
             echo "❌ No resources configuration still has non-RBAC resources"
             exit 1
           fi
           echo "✅ No resources configuration test passed"
 
-          # Test PII Analyzer
+      - name: Test PII Analyzer (both RBAC and resources)
+        run: |
           helm template stable/rad-plugins \
             --set runtime.enabled=true \
             --set runtime.httpTracingEnabled=true \
             --set runtime.piiAnalyzer.enabled=true \
             --output-dir test-output-pii
+          # Check if PII analyzer files exist
           if [ ! -f test-output-pii/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml ]; then
             echo "❌ PII analyzer not rendered"
             exit 1
           fi
+          # Verify both RBAC and non-RBAC components are in the file
           if ! grep -q "kind: ServiceAccount" test-output-pii/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml; then
             echo "❌ PII analyzer missing RBAC resources"
             exit 1
@@ -148,29 +103,57 @@ jobs:
             echo "❌ PII analyzer missing non-RBAC resources"
             exit 1
           fi
+          echo "✅ PII analyzer test passed"
 
-          # Test PII with RBAC disabled
+      - name: Test PII Analyzer (no RBAC)
+        run: |
           helm template stable/rad-plugins \
             --set runtime.enabled=true \
             --set runtime.httpTracingEnabled=true \
             --set runtime.piiAnalyzer.enabled=true \
             --set rad.deployment.rbac=false \
             --output-dir test-output-pii-no-rbac
+          # Check if PII analyzer file exists
+          if [ ! -f test-output-pii-no-rbac/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml ]; then
+            echo "❌ PII analyzer not rendered"
+            exit 1
+          fi
+          # Verify only non-RBAC components are in the file
           if grep -q "kind: ServiceAccount" test-output-pii-no-rbac/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml; then
             echo "❌ PII analyzer with RBAC disabled still has ServiceAccount"
             exit 1
           fi
+          if ! grep -q "kind: Deployment" test-output-pii-no-rbac/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml; then
+            echo "❌ PII analyzer with RBAC disabled missing non-RBAC resources"
+            exit 1
+          fi
+          echo "✅ PII analyzer (no RBAC) test passed"
 
-          # Test PII with resources disabled
+      - name: Test PII Analyzer (no resources)
+        run: |
           helm template stable/rad-plugins \
             --set runtime.enabled=true \
             --set runtime.httpTracingEnabled=true \
             --set runtime.piiAnalyzer.enabled=true \
             --set rad.deployment.resources=false \
             --output-dir test-output-pii-no-resources
+          # Check if PII analyzer file exists
+          if [ ! -f test-output-pii-no-resources/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml ]; then
+            echo "❌ PII analyzer not rendered"
+            exit 1
+          fi
+          # Verify only RBAC components are in the file
+          if ! grep -q "kind: ServiceAccount" test-output-pii-no-resources/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml; then
+            echo "❌ PII analyzer with resources disabled missing ServiceAccount"
+            exit 1
+          fi
           if grep -q "kind: Deployment" test-output-pii-no-resources/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml; then
             echo "❌ PII analyzer with resources disabled still has non-RBAC resources"
             exit 1
           fi
+          echo "✅ PII analyzer (no resources) test passed"
 
+      - name: Report success
+        if: success()
+        run: |
           echo "All RBAC/resources separation tests passed successfully!"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,3 +58,81 @@ Charts should start at `1.0.0`. Any breaking (backwards incompatible) changes to
 1. Bump the MAJOR version
 2. In the README, under a section called "Upgrading", describe the manual steps necessary to upgrade to the new (specified) MAJOR version
 3. New issue should be started to discuss the changes and the need for a new MAJOR version
+
+## Contribution Guidelines
+
+The following guidelines are to be followed when making changes to the Helm charts:
+
+* All templates should use 2 spaces for indentation
+* New dependencies should be added to the Chart.yaml file, not requirements.yaml (deprecated)
+* All resources should have meaningful labels, including but not limited to recommended labels like app, version, component, etc.
+* Always update the Chart.yaml when making changes to the templates
+* Always make sure to run the tests locally before submitting a PR
+
+## RBAC and Resources Separation
+
+This Helm chart supports the ability to deploy RBAC resources and non-RBAC resources separately. This allows users to:
+
+1. Deploy only RBAC resources (`rad.deployment.rbac=true`, `rad.deployment.resources=false`)
+2. Deploy only non-RBAC resources (`rad.deployment.rbac=false`, `rad.deployment.resources=true`)
+3. Deploy both (default behavior)
+
+When adding new resources to the chart, you must ensure they respect this separation:
+
+* For RBAC resources (ServiceAccounts, Roles, ClusterRoles, RoleBindings, ClusterRoleBindings):
+  ```yaml
+  {{- if eq (include "rad-plugins.deployRbac" .) "true" -}}
+  apiVersion: v1
+  kind: ServiceAccount
+  # ...
+  {{- end }}
+  ```
+
+* For non-RBAC resources (Deployments, Services, ConfigMaps, etc.):
+  ```yaml
+  {{- if eq (include "rad-plugins.deployResources" .) "true" -}}
+  apiVersion: apps/v1
+  kind: Deployment
+  # ...
+  {{- end }}
+  ```
+
+This separation allows users to review and apply RBAC permissions before deploying the actual workloads, which is important for security-conscious environments.
+
+### Testing RBAC/Resources Separation
+
+Changes should maintain the RBAC/resources separation capability. You can test this locally:
+
+```bash
+# Test default (both RBAC and resources)
+helm template stable/rad-plugins --set runtime.enabled=true
+
+# Test RBAC only
+helm template stable/rad-plugins --set runtime.enabled=true --set rad.deployment.resources=false
+
+# Test resources only (no RBAC)
+helm template stable/rad-plugins --set runtime.enabled=true --set rad.deployment.rbac=false
+```
+
+There are also automated tests in our CI pipeline that will verify this capability.
+
+## Pull Request Process
+
+1. Ensure all pre-commit hooks are passing by running `make pre-commit`.
+2. Update the README.md.gotmpl with details of changes to the chart, including new values, exposed ports, useful settings, and any other information that would be relevant to users.
+3. Update the Chart.yaml version following the [versioning](#versioning) guidelines.
+4. Add an entry to the `artifacthub.io/changes` section in Chart.yaml describing your changes.
+5. Run local tests to ensure your changes don't break existing functionality:
+   ```bash
+   # Lint the chart
+   helm lint stable/rad-plugins
+
+   # Test the rendered templates
+   helm template stable/rad-plugins
+
+   # If you've made RBAC/resources separation changes, run the separation tests
+   # as described in the previous section
+   ```
+6. Create a Pull Request explaining the changes you've made and why they're needed.
+7. Your PR will be reviewed by maintainers, who may request changes or ask for clarifications.
+8. Once approved, your changes will be merged, and a new chart release will be automatically created.

--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.2.11
+version: 2.2.12
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/favicon.ico
@@ -17,8 +17,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: security
-      description: Patch security vulnerabilities
+    - kind: added
+      description: Added configurations to deploy RBAC resources and non-RBAC resources separately
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -83,7 +83,9 @@ runtime:
 
 Each plugin pod contains `agent` and `exporter` containers. The `agent` container is responsible for collecting runtime information from the nodes in the cluster. The `exporter` container is responsible for exporting the collected information to the RAD Security platform.
 
-The information collected is sent to the RAD Security platform for further processing. For more information on the `rad-runtime
+Like other plugins, the rad-runtime component also respects the `rad.deployment.rbac` and `rad.deployment.resources` configuration flags to allow deploying RBAC and resources separately if needed.
+
+The information collected is sent to the RAD Security platform for further processing. For more information on the `rad-runtime` plugin, please refer to the [RAD Security](https://rad.security) documentation.
 
 ## Prerequisites
 
@@ -212,7 +214,7 @@ rad:
   accessKeySecretNameOverride: "rad-access-key"
 ```
 
-RAD Security rad-guard plugin integrates with the Kubernetes admission controller. All admission controller communications require TLS. RAD Security Helm chart installs and rad-guard utilizes Let’s Encrypt to automate the issuance and renewal of certificates using the cert-manager add-on.
+RAD Security rad-guard plugin integrates with the Kubernetes admission controller. All admission controller communications require TLS. RAD Security Helm chart installs and rad-guard utilizes Let's Encrypt to automate the issuance and renewal of certificates using the cert-manager add-on.
 
 #### 4.2 AWS Secret Manager
 
@@ -498,6 +500,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | rad.base64AccessKeyId | string | `""` | The ID of the Access Key used in this cluster (base64). |
 | rad.base64SecretKey | string | `""` | The secret key part of the Access Key used in this cluster (base64). |
 | rad.clusterName | string | `""` | The name of the cluster you want displayed in RAD Security. |
+| rad.deployment | object | `{"rbac":true,"resources":true}` | Control which types of resources to deploy |
+| rad.deployment.rbac | bool | `true` | Deploy RBAC resources (ServiceAccounts, Roles, ClusterRoles, RoleBindings, ClusterRoleBindings) If false, no RBAC resources will be deployed |
+| rad.deployment.resources | bool | `true` | Deploy non-RBAC resources (Deployments, Services, ConfigMaps, Secrets, etc.) If false, no non-RBAC resources will be deployed |
 | rad.seccompProfile | object | `{"enabled":true}` | Enable seccompProfile for all RAD Security pods |
 | runtime.agent.collectors.containerd.enabled | string | `nil` |  |
 | runtime.agent.collectors.containerd.socket | string | `"/run/containerd/containerd.sock"` |  |

--- a/stable/rad-plugins/README.md.gotmpl
+++ b/stable/rad-plugins/README.md.gotmpl
@@ -83,7 +83,9 @@ runtime:
 
 Each plugin pod contains `agent` and `exporter` containers. The `agent` container is responsible for collecting runtime information from the nodes in the cluster. The `exporter` container is responsible for exporting the collected information to the RAD Security platform.
 
-The information collected is sent to the RAD Security platform for further processing. For more information on the `rad-runtime
+Like other plugins, the rad-runtime component also respects the `rad.deployment.rbac` and `rad.deployment.resources` configuration flags to allow deploying RBAC and resources separately if needed.
+
+The information collected is sent to the RAD Security platform for further processing. For more information on the `rad-runtime` plugin, please refer to the [RAD Security](https://rad.security) documentation.
 
 ## Prerequisites
 
@@ -212,7 +214,7 @@ rad:
   accessKeySecretNameOverride: "rad-access-key"
 ```
 
-RAD Security rad-guard plugin integrates with the Kubernetes admission controller. All admission controller communications require TLS. RAD Security Helm chart installs and rad-guard utilizes Let’s Encrypt to automate the issuance and renewal of certificates using the cert-manager add-on.
+RAD Security rad-guard plugin integrates with the Kubernetes admission controller. All admission controller communications require TLS. RAD Security Helm chart installs and rad-guard utilizes Let's Encrypt to automate the issuance and renewal of certificates using the cert-manager add-on.
 
 #### 4.2 AWS Secret Manager
 

--- a/stable/rad-plugins/templates/_helpers.tpl
+++ b/stable/rad-plugins/templates/_helpers.tpl
@@ -100,3 +100,33 @@ rad-bootstrap initContainer
   resources:
 {{ toYaml .Values.bootstrapper.resources | indent 4 }}
 {{- end -}}
+
+{{/*
+Check if RBAC resources should be deployed
+*/}}
+{{- define "rad-plugins.deployRbac" -}}
+{{- if hasKey .Values.rad "deployment" -}}
+{{- if hasKey .Values.rad.deployment "rbac" -}}
+{{- .Values.rad.deployment.rbac -}}
+{{- else -}}
+{{- true -}}
+{{- end -}}
+{{- else -}}
+{{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Check if non-RBAC resources should be deployed
+*/}}
+{{- define "rad-plugins.deployResources" -}}
+{{- if hasKey .Values.rad "deployment" -}}
+{{- if hasKey .Values.rad.deployment "resources" -}}
+{{- .Values.rad.deployment.resources -}}
+{{- else -}}
+{{- true -}}
+{{- end -}}
+{{- else -}}
+{{- true -}}
+{{- end -}}
+{{- end -}}

--- a/stable/rad-plugins/templates/guard/deployment.yaml
+++ b/stable/rad-plugins/templates/guard/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.guard.enabled -}}
+{{- if eq (include "rad-plugins.deployResources" .) "true" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -126,4 +127,5 @@ spec:
       - name: api-token
         secret:
           secretName: rad-guard-api-token-secret
+{{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/guard/mutating-webhook-config.yaml
+++ b/stable/rad-plugins/templates/guard/mutating-webhook-config.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.guard.enabled -}}
+{{- if eq (include "rad-plugins.deployResources" .) "true" -}}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -43,4 +44,5 @@ webhooks:
         operations: [ "CREATE", "UPDATE" ]
         resources: [ "pods", "namespaces" ]
     sideEffects: NoneOnDryRun
+{{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/guard/rbac.yaml
+++ b/stable/rad-plugins/templates/guard/rbac.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.guard.enabled -}}
+{{- if eq (include "rad-plugins.deployRbac" .) "true" -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -167,7 +168,6 @@ subjects:
   - kind: ServiceAccount
     name: rad-guard
     namespace: {{ .Release.Namespace }}
-
----
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/rad-plugins/templates/guard/service.yaml
+++ b/stable/rad-plugins/templates/guard/service.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.guard.enabled -}}
+{{- if eq (include "rad-plugins.deployResources" .) "true" -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,4 +18,5 @@ spec:
     app_name: rad-guard
     app_version: {{ .Values.guard.image.tag | quote }}
     maintained_by: rad.security
+{{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/rbac.yaml
+++ b/stable/rad-plugins/templates/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "rad-plugins.deployRbac" .) "true" -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -80,3 +81,4 @@ rules:
 
 ---
 {{ end -}}
+{{- end -}}

--- a/stable/rad-plugins/templates/runtime/daemonset.yaml
+++ b/stable/rad-plugins/templates/runtime/daemonset.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.runtime .Values.runtime.enabled -}}
+{{- if eq (include "rad-plugins.deployResources" .) "true" -}}
 {{- $openshiftEnabled := and .Values.openshift .Values.openshift.enabled }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
@@ -295,4 +296,5 @@ spec:
         {{- with .Values.runtime.agent.mounts.volumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/stable/rad-plugins/templates/runtime/dynamic-config.yaml
+++ b/stable/rad-plugins/templates/runtime/dynamic-config.yaml
@@ -1,3 +1,5 @@
+{{- if and .Values.runtime .Values.runtime.enabled -}}
+{{- if eq (include "rad-plugins.deployResources" .) "true" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,11 +9,8 @@ metadata:
     app_name: rad-runtime
     app_version: {{ .Values.runtime.agent.image.tag | quote }}
     maintained_by: rad.security
-data:
-# Placeholder for dynamic configuration
-
+data: {}
 ---
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -21,5 +20,6 @@ metadata:
     app_name: rad-runtime
     app_version: {{ .Values.runtime.agent.image.tag | quote }}
     maintained_by: rad.security
-data:
-# Placeholder for dynamic configuration
+data: {}
+{{- end }}
+{{- end }}

--- a/stable/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml
+++ b/stable/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml
@@ -1,6 +1,8 @@
 {{- if and .Values.runtime .Values.runtime.enabled -}}
 {{- if .Values.runtime.httpTracingEnabled }}
 {{- if and .Values.runtime.piiAnalyzer .Values.runtime.piiAnalyzer.enabled -}}
+
+{{- if eq (include "rad-plugins.deployRbac" .) "true" -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -16,6 +18,9 @@ metadata:
   {{- end }}
 automountServiceAccountToken: false
 ---
+{{- end }}
+
+{{- if eq (include "rad-plugins.deployResources" .) "true" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -96,6 +101,7 @@ spec:
     name: rad-pii-analyzer
   selector:
     app: rad-pii-analyzer
+{{- end }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/runtime/rbac.yaml
+++ b/stable/rad-plugins/templates/runtime/rbac.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.runtime .Values.runtime.enabled -}}
+{{- if eq (include "rad-plugins.deployRbac" .) "true" -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -131,5 +132,6 @@ subjects:
 
 ---
 
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/rad-plugins/templates/sbom/rbac.yaml
+++ b/stable/rad-plugins/templates/sbom/rbac.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.sbom.enabled -}}
+{{- if eq (include "rad-plugins.deployRbac" .) "true" -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -161,8 +162,6 @@ subjects:
   - kind: ServiceAccount
     name: rad-sbom
     namespace: {{ .Release.Namespace }}
-
----
-
+{{ end }}
 {{- end }}
 {{- end }}

--- a/stable/rad-plugins/templates/sync/rbac.yaml
+++ b/stable/rad-plugins/templates/sync/rbac.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.sync.enabled -}}
+{{- if eq (include "rad-plugins.deployRbac" .) "true" -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -102,7 +103,7 @@ subjects:
 
 ---
 
-{{ if ( eq .Values.eksAddon.enabled false ) -}}
+{{ if ( eq .Values.eksAddon.enabled false ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -119,8 +120,6 @@ subjects:
   - kind: ServiceAccount
     name: rad-sync
     namespace: {{ .Release.Namespace }}
-
----
-
+{{ end }}
 {{- end }}
 {{- end }}

--- a/stable/rad-plugins/templates/watch/rbac.yaml
+++ b/stable/rad-plugins/templates/watch/rbac.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.watch.enabled -}}
+{{- if eq (include "rad-plugins.deployRbac" .) "true" -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -154,8 +155,6 @@ subjects:
   - kind: ServiceAccount
     name: rad-watch
     namespace: {{ .Release.Namespace }}
-
----
-
+{{ end }}
 {{- end }}
 {{- end }}

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -18,6 +18,14 @@ rad:
   # -- Enable seccompProfile for all RAD Security pods
   seccompProfile:
     enabled: true
+  # -- Control which types of resources to deploy
+  deployment:
+    # -- Deploy RBAC resources (ServiceAccounts, Roles, ClusterRoles, RoleBindings, ClusterRoleBindings)
+    # If false, no RBAC resources will be deployed
+    rbac: true
+    # -- Deploy non-RBAC resources (Deployments, Services, ConfigMaps, Secrets, etc.)
+    # If false, no non-RBAC resources will be deployed
+    resources: true
 
 workloads:
   # -- Whether to disable service mesh integration.


### PR DESCRIPTION
#### What this PR does / why we need it
This change implements the ability to selectively deploy RBAC resources and non-RBAC resources independently, a customer-requested feature. The implementation:

- Adds rad.deployment.rbac and rad.deployment.resources flags (both default to true)
- Introduces helper functions to check these flags in helpers.tpl
- Wraps all resources in appropriate conditionals to respect these flags
- Ensures runtime components (including PII analyzer) respect these settings
- Adds comprehensive CI tests to prevent regressions
- Updates documentation for users and future contributors

The default behavior remains unchanged to maintain backward compatibility.

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
