### PR TITLE
Enable separate deployments to release namespace and kube-system

### DIFF
--- a/.github/workflows/test-namespace-deployment.yaml
+++ b/.github/workflows/test-namespace-deployment.yaml
@@ -1,119 +1,84 @@
-name: checks
+name: Test Namespace-Based Deployment
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'stable/rad-plugins/**'
   pull_request:
-
-# Cancel any in-flight jobs for the same PR branch so there's only one active at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    branches: [ main ]
+    paths:
+      - 'stable/rad-plugins/**'
+  workflow_dispatch:
 
 jobs:
-  pre-commit:
-    permissions:
-      contents: read
+  test-namespace-deployment:
     runs-on: ubuntu-latest
-    container: us.gcr.io/ksoc-public/kubernetes-toolkit:1.29.4
     steps:
-      - name: clone repo
-        uses: actions/checkout@v4
-      - name: pre-commit checks
-        run: pre-commit-checks
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-  deprecation-checks:
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    container: us.gcr.io/ksoc-public/kubernetes-toolkit:1.29.4
-    steps:
-      - name: clone repo
-        uses: actions/checkout@v4
-      - name: deprecation-checks
-        run: make deprecation-checks
-
-  kubeval-checks:
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    container: us.gcr.io/ksoc-public/kubernetes-toolkit:1.29.4
-    steps:
-      - name: clone repo
-        uses: actions/checkout@v4
-      - name: kubeval-checks
-        run: make kubeval-checks
-
-  lint:
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.14.2
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
-      - name: Run chart-testing (lint)
-        run: ct lint --config test/ct.yaml
-      - name: Run helm lint
-        run: helm lint stable/rad-plugins
+          version: v3.11.2
 
-  namespace-deployment:
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.14.2
-      - name: Test Namespace-Based Deployment
+      - name: Create test directories
         run: |
-          # Create test directories
           mkdir -p test-output-{default,release-only,kube-system-only}
 
-          # Test default (both namespaces)
+      - name: Test default (both namespaces)
+        run: |
           helm template stable/rad-plugins \
             --set runtime.enabled=true \
             --output-dir test-output-default
           echo "Default configuration file count: $(find test-output-default -type f | wc -l)"
+
+          # Verify resources are in the release namespace
           if ! grep -q "namespace:" test-output-default/rad-plugins/templates/guard/deployment.yaml; then
             echo "❌ Default configuration missing namespace in guard deployment"
             exit 1
           fi
+
+          # Verify resources are in kube-system namespace
           if ! grep -q "namespace: kube-system" test-output-default/rad-plugins/templates/rbac.yaml; then
             echo "❌ Default configuration missing resources in kube-system namespace"
             exit 1
           fi
 
-          # Test release namespace only
+          echo "✅ Default configuration test passed"
+
+      - name: Test release namespace only
+        run: |
           helm template stable/rad-plugins \
             --set runtime.enabled=true \
             --set rad.deployment.kubeSystem=false \
             --output-dir test-output-release-only
+          echo "Release namespace only configuration file count: $(find test-output-release-only -type f | wc -l)"
+
+          # Verify resources are in the release namespace
           if ! grep -q "namespace:" test-output-release-only/rad-plugins/templates/guard/deployment.yaml; then
             echo "❌ Release namespace only configuration missing namespace in guard deployment"
             exit 1
           fi
+
+          # Verify no resources in kube-system namespace by checking RoleBinding to kube-root-ca-reader is not present
           if grep -q "name: rad-guard-kube-root-ca-reader" test-output-release-only/rad-plugins/templates/guard/rbac.yaml; then
             echo "❌ Release namespace only configuration still has resources in kube-system namespace"
             exit 1
           fi
 
-          # Test kube-system namespace only
+          echo "✅ Release namespace only configuration test passed"
+
+      - name: Test kube-system namespace only
+        run: |
           helm template stable/rad-plugins \
             --set runtime.enabled=true \
             --set rad.deployment.releaseNamespace=false \
             --output-dir test-output-kube-system-only
+          echo "Kube-system namespace only configuration file count: $(find test-output-kube-system-only -type f | wc -l)"
+
+          # Verify no deployments in release namespace
           if [ -f test-output-kube-system-only/rad-plugins/templates/guard/deployment.yaml ]; then
             echo "❌ Kube-system namespace only configuration still has deployments in release namespace"
             exit 1
@@ -125,20 +90,54 @@ jobs:
             exit 1
           fi
 
+          # Verify ClusterRoles still exist (they're not namespace-specific)
+          found_cluster_role=false
+          if grep -q "kind: ClusterRole" test-output-kube-system-only/rad-plugins/templates/guard/rbac.yaml; then
+            found_cluster_role=true
+          fi
+          if [ "$found_cluster_role" != "true" ]; then
+            echo "❌ Kube-system namespace only configuration missing cluster roles"
+            exit 1
+          fi
+
           # NOTE: We don't check subjects in bindings since they will reference ServiceAccounts in the default namespace
           # when running the test. This is expected behavior when .Release.Namespace resolves to "default"
           # during the helm template command.
 
-          # Test PII analyzer
+          echo "✅ Kube-system namespace only configuration test passed"
+
+      - name: Test runtime PII analyzer
+        run: |
+          # Test with both namespaces (default)
+          helm template stable/rad-plugins \
+            --set runtime.enabled=true \
+            --set runtime.httpTracingEnabled=true \
+            --set runtime.piiAnalyzer.enabled=true \
+            --output-dir test-output-pii-default
+
+          # Verify PII analyzer deployed in release namespace
+          if [ ! -f test-output-pii-default/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml ]; then
+            echo "❌ PII analyzer not rendered in default configuration"
+            exit 1
+          fi
+
+          # Test with release namespace disabled
           helm template stable/rad-plugins \
             --set runtime.enabled=true \
             --set runtime.httpTracingEnabled=true \
             --set runtime.piiAnalyzer.enabled=true \
             --set rad.deployment.releaseNamespace=false \
-            --output-dir test-output-pii
-          if [ -f test-output-pii/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml ]; then
+            --output-dir test-output-pii-no-release
+
+          # Verify PII analyzer not deployed when release namespace is disabled
+          if [ -f test-output-pii-no-release/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml ]; then
             echo "❌ PII analyzer still rendered when release namespace is disabled"
             exit 1
           fi
 
+          echo "✅ PII analyzer test passed"
+
+      - name: Report success
+        if: success()
+        run: |
           echo "All namespace-based deployment tests passed successfully!"

--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.2.12
+version: 2.3.0
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/favicon.ico

--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.2.11
+version: 2.2.12
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/favicon.ico
@@ -17,8 +17,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: security
-      description: Patch security vulnerabilities
+    - kind: added
+      description: Added config to enable separate helm ops by namespace
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -24,7 +24,7 @@ In this way, we can avoid the degradation of the API server, which would occur i
 
 ### rad-sbom plugin
 
-`rad-sbom` is the plugin responsible for calculating [SBOMs](https://en.wikipedia.org/wiki/Software_supply_chain) directly on the customer cluster. The plugin is run as an admission/mutating webhook, adding an image digest next to its tag if it's missing. This mutation is performed so [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use) does not impact the user. The image deployed is the image that RAD Security scanned. It sees all new workloads and calculates SBOMs for them. It continuously checks the RAD Security API to save time and resources to see if the SBOM is already known for any particular image digest. If not, it is being calculated and uploaded to RAD Security for further processing. By default we use `cyclonedx-json` format for SBOMs, but it can be changed to `spdx-json` or `syft-json` by setting the `SBOM_FORMAT` environment variable in the `values.yaml` file. To prevent the plugin from mutating the `Pod` resource, set the `MUTATE_IMAGE` and `MUTATE_ANNOTATIONS` environment variables to `false`. If observe a performance degradation while deploying new workloads, you can improve it significantly by disabling the mutation of the image tag and annotations.
+`rad-sbom` is the plugin responsible for calculating [SBOMs](https://en.wikipedia.org/wiki/Software_supply_chain) directly on the customer cluster. The plugin is run as an admission/mutating webhook, adding an image digest next to its tag if it's missing. This mutation is performed so [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of_use) does not impact the user. The image deployed is the image that RAD Security scanned. It sees all new workloads and calculates SBOMs for them. It continuously checks the RAD Security API to save time and resources to see if the SBOM is already known for any particular image digest. If not, it is being calculated and uploaded to RAD Security for further processing. By default we use `cyclonedx-json` format for SBOMs, but it can be changed to `spdx-json` or `syft-json` by setting the `SBOM_FORMAT` environment variable in the `values.yaml` file. To prevent the plugin from mutating the `Pod` resource, set the `MUTATE_IMAGE` and `MUTATE_ANNOTATIONS` environment variables to `false`. If observe a performance degradation while deploying new workloads, you can improve it significantly by disabling the mutation of the image tag and annotations.
 
 ```yaml
 sbom:
@@ -212,7 +212,7 @@ rad:
   accessKeySecretNameOverride: "rad-access-key"
 ```
 
-RAD Security rad-guard plugin integrates with the Kubernetes admission controller. All admission controller communications require TLS. RAD Security Helm chart installs and rad-guard utilizes Let’s Encrypt to automate the issuance and renewal of certificates using the cert-manager add-on.
+RAD Security rad-guard plugin integrates with the Kubernetes admission controller. All admission controller communications require TLS. RAD Security Helm chart installs and rad-guard utilizes Let's Encrypt to automate the issuance and renewal of certificates using the cert-manager add-on.
 
 #### 4.2 AWS Secret Manager
 
@@ -498,6 +498,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | rad.base64AccessKeyId | string | `""` | The ID of the Access Key used in this cluster (base64). |
 | rad.base64SecretKey | string | `""` | The secret key part of the Access Key used in this cluster (base64). |
 | rad.clusterName | string | `""` | The name of the cluster you want displayed in RAD Security. |
+| rad.deployment | object | `{"kubeSystem":true,"releaseNamespace":true}` | Control which namespaces to deploy resources to |
+| rad.deployment.kubeSystem | bool | `true` | Deploy resources in the kube-system namespace If false, no resources will be deployed in the kube-system namespace |
+| rad.deployment.releaseNamespace | bool | `true` | Deploy resources in the release namespace (the namespace where the chart is installed) If false, no resources will be deployed in the release namespace |
 | rad.seccompProfile | object | `{"enabled":true}` | Enable seccompProfile for all RAD Security pods |
 | runtime.agent.collectors.containerd.enabled | string | `nil` |  |
 | runtime.agent.collectors.containerd.socket | string | `"/run/containerd/containerd.sock"` |  |
@@ -604,3 +607,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | watch.tolerations | list | `[]` |  |
 | workloads.disableServiceMesh | bool | `true` | Whether to disable service mesh integration. |
 | workloads.imagePullSecretName | string | `""` | The image pull secret name to use to pull container images. |
+
+| rad.clusterName | The name of the cluster you want displayed in RAD Security. | `""` |
+| rad.accessKeySecretNameOverride | The name of the custom secret containing Access Key. | `""` |
+| rad.seccompProfile.enabled | Enable seccompProfile for all RAD Security pods | `true` |
+| rad.deployment.releaseNamespace | Deploy resources in the release namespace (the namespace where the chart is installed). If false, no resources will be deployed in the release namespace. | `true` |
+| rad.deployment.kubeSystem | Deploy resources in the kube-system namespace. If false, no resources will be deployed in the kube-system namespace. | `true` |
+| workloads.disableServiceMesh | Whether to disable service mesh integration. | `true` |

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -499,8 +499,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | rad.base64SecretKey | string | `""` | The secret key part of the Access Key used in this cluster (base64). |
 | rad.clusterName | string | `""` | The name of the cluster you want displayed in RAD Security. |
 | rad.deployment | object | `{"kubeSystem":true,"releaseNamespace":true}` | Control which namespaces to deploy resources to |
-| rad.deployment.kubeSystem | bool | `true` | Deploy resources in the kube-system namespace If false, no resources will be deployed in the kube-system namespace |
-| rad.deployment.releaseNamespace | bool | `true` | Deploy resources in the release namespace (the namespace where the chart is installed) If false, no resources will be deployed in the release namespace |
+| rad.deployment.kubeSystem | bool | `true` | Deploy resources in the kube-system namespace. If false, no resources will be deployed in the kube-system namespace. |
+| rad.deployment.releaseNamespace | bool | `true` | Deploy resources in the release namespace (the namespace where the chart is installed). If false, no resources will be deployed in the release namespace. |
 | rad.seccompProfile | object | `{"enabled":true}` | Enable seccompProfile for all RAD Security pods |
 | runtime.agent.collectors.containerd.enabled | string | `nil` |  |
 | runtime.agent.collectors.containerd.socket | string | `"/run/containerd/containerd.sock"` |  |

--- a/stable/rad-plugins/README.md.gotmpl
+++ b/stable/rad-plugins/README.md.gotmpl
@@ -24,7 +24,7 @@ In this way, we can avoid the degradation of the API server, which would occur i
 
 ### rad-sbom plugin
 
-`rad-sbom` is the plugin responsible for calculating [SBOMs](https://en.wikipedia.org/wiki/Software_supply_chain) directly on the customer cluster. The plugin is run as an admission/mutating webhook, adding an image digest next to its tag if it's missing. This mutation is performed so [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use) does not impact the user. The image deployed is the image that RAD Security scanned. It sees all new workloads and calculates SBOMs for them. It continuously checks the RAD Security API to save time and resources to see if the SBOM is already known for any particular image digest. If not, it is being calculated and uploaded to RAD Security for further processing. By default we use `cyclonedx-json` format for SBOMs, but it can be changed to `spdx-json` or `syft-json` by setting the `SBOM_FORMAT` environment variable in the `values.yaml` file. To prevent the plugin from mutating the `Pod` resource, set the `MUTATE_IMAGE` and `MUTATE_ANNOTATIONS` environment variables to `false`. If observe a performance degradation while deploying new workloads, you can improve it significantly by disabling the mutation of the image tag and annotations.
+`rad-sbom` is the plugin responsible for calculating [SBOMs](https://en.wikipedia.org/wiki/Software_supply_chain) directly on the customer cluster. The plugin is run as an admission/mutating webhook, adding an image digest next to its tag if it's missing. This mutation is performed so [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of_use) does not impact the user. The image deployed is the image that RAD Security scanned. It sees all new workloads and calculates SBOMs for them. It continuously checks the RAD Security API to save time and resources to see if the SBOM is already known for any particular image digest. If not, it is being calculated and uploaded to RAD Security for further processing. By default we use `cyclonedx-json` format for SBOMs, but it can be changed to `spdx-json` or `syft-json` by setting the `SBOM_FORMAT` environment variable in the `values.yaml` file. To prevent the plugin from mutating the `Pod` resource, set the `MUTATE_IMAGE` and `MUTATE_ANNOTATIONS` environment variables to `false`. If observe a performance degradation while deploying new workloads, you can improve it significantly by disabling the mutation of the image tag and annotations.
 
 ```yaml
 sbom:
@@ -212,7 +212,7 @@ rad:
   accessKeySecretNameOverride: "rad-access-key"
 ```
 
-RAD Security rad-guard plugin integrates with the Kubernetes admission controller. All admission controller communications require TLS. RAD Security Helm chart installs and rad-guard utilizes Let’s Encrypt to automate the issuance and renewal of certificates using the cert-manager add-on.
+RAD Security rad-guard plugin integrates with the Kubernetes admission controller. All admission controller communications require TLS. RAD Security Helm chart installs and rad-guard utilizes Let's Encrypt to automate the issuance and renewal of certificates using the cert-manager add-on.
 
 #### 4.2 AWS Secret Manager
 
@@ -448,3 +448,10 @@ helm uninstall rad -n rad
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
 {{ template "chart.valuesSection" . }}
+
+| rad.clusterName | The name of the cluster you want displayed in RAD Security. | `""` |
+| rad.accessKeySecretNameOverride | The name of the custom secret containing Access Key. | `""` |
+| rad.seccompProfile.enabled | Enable seccompProfile for all RAD Security pods | `true` |
+| rad.deployment.releaseNamespace | Deploy resources in the release namespace (the namespace where the chart is installed). If false, no resources will be deployed in the release namespace. | `true` |
+| rad.deployment.kubeSystem | Deploy resources in the kube-system namespace. If false, no resources will be deployed in the kube-system namespace. | `true` |
+| workloads.disableServiceMesh | Whether to disable service mesh integration. | `true` |

--- a/stable/rad-plugins/templates/_helpers.tpl
+++ b/stable/rad-plugins/templates/_helpers.tpl
@@ -100,3 +100,33 @@ rad-bootstrap initContainer
   resources:
 {{ toYaml .Values.bootstrapper.resources | indent 4 }}
 {{- end -}}
+
+{{/*
+Check if resources in the release namespace should be deployed
+*/}}
+{{- define "rad-plugins.deployInReleaseNamespace" -}}
+{{- if hasKey .Values.rad "deployment" -}}
+{{- if hasKey .Values.rad.deployment "releaseNamespace" -}}
+{{- .Values.rad.deployment.releaseNamespace -}}
+{{- else -}}
+{{- true -}}
+{{- end -}}
+{{- else -}}
+{{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Check if resources in the kube-system namespace should be deployed
+*/}}
+{{- define "rad-plugins.deployInKubeSystem" -}}
+{{- if hasKey .Values.rad "deployment" -}}
+{{- if hasKey .Values.rad.deployment "kubeSystem" -}}
+{{- .Values.rad.deployment.kubeSystem -}}
+{{- else -}}
+{{- true -}}
+{{- end -}}
+{{- else -}}
+{{- true -}}
+{{- end -}}
+{{- end -}}

--- a/stable/rad-plugins/templates/guard/cert.yaml
+++ b/stable/rad-plugins/templates/guard/cert.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.guard.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -16,4 +17,5 @@ spec:
     kind: Issuer
     name: rad-selfsigned-issuer
   secretName: rad-guard-self-signed-cert
+{{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/guard/deployment.yaml
+++ b/stable/rad-plugins/templates/guard/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.guard.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -126,4 +127,5 @@ spec:
       - name: api-token
         secret:
           secretName: rad-guard-api-token-secret
+{{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/guard/dynamic-config.yaml
+++ b/stable/rad-plugins/templates/guard/dynamic-config.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.guard.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,3 +12,6 @@ metadata:
 data:
 # Placeholder for dynamic configuration created via rad-sync
 # Main purpose of this ConfigMap is to delete it when rad-plugins helm chart is uninstalled
+  config: "{}"
+{{- end -}}
+{{- end -}}

--- a/stable/rad-plugins/templates/guard/mutating-webhook-config.yaml
+++ b/stable/rad-plugins/templates/guard/mutating-webhook-config.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.guard.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -12,7 +13,7 @@ metadata:
     maintained_by: rad.security
 webhooks:
   - admissionReviewVersions:
-      - v1
+    - v1
     clientConfig:
       service:
         name: rad-guard
@@ -43,4 +44,5 @@ webhooks:
         operations: [ "CREATE", "UPDATE" ]
         resources: [ "pods", "namespaces" ]
     sideEffects: NoneOnDryRun
+{{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/guard/rbac.yaml
+++ b/stable/rad-plugins/templates/guard/rbac.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.guard.enabled -}}
+
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -49,49 +51,6 @@ rules:
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: rad-guard
-  labels:
-    app_name: rad-guard
-    app_version: {{ .Values.guard.image.tag | quote }}
-    maintained_by: rad.security
-rules:
-  - apiGroups: [ "apiextensions.k8s.io" ]
-    resources: [ "customresourcedefinitions" ]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-  - apiGroups: [ "ksoc.com" ]
-    resources: [ "guardpolicies" ]
-    verbs: [ "get", "list", "watch", "update" ]
-  - apiGroups: [ "ksoc.com" ]
-    resources: [ "guardresults" ]
-    verbs: [ "create", "delete", "list", "watch" ]
-  - apiGroups: [ "ksoc.com" ]
-    resources: [ "guardpolicies/status", "guardresults/status" ]
-    verbs: [ "get" ]
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: rad-guard
-  labels:
-    app_name: rad-guard
-    app_version: {{ .Values.guard.image.tag | quote }}
-    maintained_by: rad.security
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: rad-guard
-subjects:
-- kind: ServiceAccount
-  name: rad-guard
-  namespace: {{ .Release.Namespace }}
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: rad-guard-configmap-reader
@@ -128,6 +87,52 @@ subjects:
   - kind: ServiceAccount
     name: rad-guard
     namespace: {{ .Release.Namespace }}
+{{- end }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rad-guard
+  labels:
+    app_name: rad-guard
+    app_version: {{ .Values.guard.image.tag | quote }}
+    maintained_by: rad.security
+rules:
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: [ "customresourcedefinitions" ]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [ "ksoc.com" ]
+    resources: [ "guardpolicies" ]
+    verbs: [ "get", "list", "watch", "update" ]
+  - apiGroups: [ "ksoc.com" ]
+    resources: [ "guardresults" ]
+    verbs: [ "create", "delete", "list", "watch" ]
+  - apiGroups: [ "ksoc.com" ]
+    resources: [ "guardpolicies/status", "guardresults/status" ]
+    verbs: [ "get" ]
+
+---
+
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rad-guard
+  labels:
+    app_name: rad-guard
+    app_version: {{ .Values.guard.image.tag | quote }}
+    maintained_by: rad.security
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rad-guard
+subjects:
+- kind: ServiceAccount
+  name: rad-guard
+  namespace: {{ .Release.Namespace }}
+{{- end }}
 
 ---
 
@@ -146,11 +151,11 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rad-guard
-    namespace: system
+    namespace: {{ .Release.Namespace }}
 
 ---
 
-{{- if ( eq .Values.eksAddon.enabled false ) }}
+{{- if and ( eq .Values.eksAddon.enabled false ) ( eq (include "rad-plugins.deployInKubeSystem" .) "true" ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -167,7 +172,5 @@ subjects:
   - kind: ServiceAccount
     name: rad-guard
     namespace: {{ .Release.Namespace }}
-
----
 {{- end }}
 {{- end }}

--- a/stable/rad-plugins/templates/guard/service.yaml
+++ b/stable/rad-plugins/templates/guard/service.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.guard.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,4 +18,5 @@ spec:
     app_name: rad-guard
     app_version: {{ .Values.guard.image.tag | quote }}
     maintained_by: rad.security
+{{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/guard/validating-webhook-config.yaml
+++ b/stable/rad-plugins/templates/guard/validating-webhook-config.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.guard.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -12,7 +13,7 @@ metadata:
     maintained_by: rad.security
 webhooks:
   - admissionReviewVersions:
-      - v1
+    - v1
     clientConfig:
       service:
         name: rad-guard
@@ -43,4 +44,5 @@ webhooks:
         operations: [ "CREATE", "UPDATE" ]
         resources: [ "pods", "namespaces" ]
     sideEffects: NoneOnDryRun
+{{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/rbac.yaml
+++ b/stable/rad-plugins/templates/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -39,6 +40,7 @@ rules:
     verbs:
       - create
       - patch
+{{- end }}
 
 ---
 
@@ -64,7 +66,7 @@ rules:
 
 ---
 
-{{ if ( eq .Values.eksAddon.enabled false ) -}}
+{{- if and ( eq .Values.eksAddon.enabled false ) ( eq (include "rad-plugins.deployInKubeSystem" .) "true" ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -77,6 +79,4 @@ rules:
     resources: [ "configmaps" ]
     resourceNames: [ "kube-root-ca.crt" ]
     verbs: ["get", "watch", "list"]
-
----
-{{ end -}}
+{{- end }}

--- a/stable/rad-plugins/templates/runtime/daemonset.yaml
+++ b/stable/rad-plugins/templates/runtime/daemonset.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.runtime .Values.runtime.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 {{- $openshiftEnabled := and .Values.openshift .Values.openshift.enabled }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
@@ -295,4 +296,5 @@ spec:
         {{- with .Values.runtime.agent.mounts.volumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/stable/rad-plugins/templates/runtime/dynamic-config.yaml
+++ b/stable/rad-plugins/templates/runtime/dynamic-config.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.runtime.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,10 +10,11 @@ metadata:
     app_version: {{ .Values.runtime.agent.image.tag | quote }}
     maintained_by: rad.security
 data:
-# Placeholder for dynamic configuration
+  config: "{}"
+{{- end -}}
 
+{{- if and .Values.runtime.exporter.enabled (eq (include "rad-plugins.deployInReleaseNamespace" .) "true") -}}
 ---
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -22,4 +25,6 @@ metadata:
     app_version: {{ .Values.runtime.agent.image.tag | quote }}
     maintained_by: rad.security
 data:
-# Placeholder for dynamic configuration
+  config: "{}"
+{{- end -}}
+{{- end -}}

--- a/stable/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml
+++ b/stable/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml
@@ -1,6 +1,7 @@
 {{- if and .Values.runtime .Values.runtime.enabled -}}
 {{- if .Values.runtime.httpTracingEnabled }}
 {{- if and .Values.runtime.piiAnalyzer .Values.runtime.piiAnalyzer.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -96,6 +97,7 @@ spec:
     name: rad-pii-analyzer
   selector:
     app: rad-pii-analyzer
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/runtime/rbac.yaml
+++ b/stable/rad-plugins/templates/runtime/rbac.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.runtime .Values.runtime.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -49,6 +50,27 @@ type: kubernetes.io/service-account-token
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rad-runtime-configmap-reader
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app_name: rad-runtime
+    app_version: {{ .Values.runtime.agent.image.tag | quote }}
+    maintained_by: rad.security
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rad-runtime-configmap-reader
+subjects:
+  - kind: ServiceAccount
+    name: rad-runtime
+    namespace: {{ .Release.Namespace }}
+{{- end -}}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: rad-runtime
@@ -71,6 +93,7 @@ rules:
 
 ---
 
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -87,11 +110,11 @@ subjects:
   - kind: ServiceAccount
     name: rad-runtime
     namespace: {{ .Release.Namespace }}
+{{- end -}}
 
 ---
 
-{{- if ( eq .Values.eksAddon.enabled false ) }}
-
+{{- if and ( eq .Values.eksAddon.enabled false ) ( eq (include "rad-plugins.deployInKubeSystem" .) "true" ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -108,28 +131,5 @@ subjects:
   - kind: ServiceAccount
     name: rad-runtime
     namespace: {{ .Release.Namespace }}
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: rad-runtime-configmap-reader
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app_name: rad-runtime
-    app_version: {{ .Values.runtime.agent.image.tag | quote }}
-    maintained_by: rad.security
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: rad-runtime-configmap-reader
-subjects:
-  - kind: ServiceAccount
-    name: rad-runtime
-    namespace: {{ .Release.Namespace }}
-
----
-
 {{- end }}
 {{- end }}

--- a/stable/rad-plugins/templates/sbom/cert.yaml
+++ b/stable/rad-plugins/templates/sbom/cert.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.sbom.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -16,4 +17,5 @@ spec:
     kind: Issuer
     name: rad-selfsigned-issuer
   secretName: rad-sbom-self-signed-cert
+{{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/sbom/deployment.yaml
+++ b/stable/rad-plugins/templates/sbom/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.sbom.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -129,4 +130,5 @@ spec:
       - name: api-token
         secret:
           secretName: rad-sbom-api-token-secret
+{{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/sbom/dynamic-config.yaml
+++ b/stable/rad-plugins/templates/sbom/dynamic-config.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.sbom.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,3 +12,6 @@ metadata:
 data:
 # Placeholder for dynamic configuration created via rad-sync
 # Main purpose of this ConfigMap is to delete it when rad-plugins helm chart is uninstalled
+  config: "{}"
+{{- end -}}
+{{- end -}}

--- a/stable/rad-plugins/templates/sbom/mutating-webhook-config.yaml
+++ b/stable/rad-plugins/templates/sbom/mutating-webhook-config.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.sbom.enabled -}}
----
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -34,4 +34,5 @@ webhooks:
     resources:
     - pods
   sideEffects: NoneOnDryRun
+{{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/sbom/rbac.yaml
+++ b/stable/rad-plugins/templates/sbom/rbac.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.sbom.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -13,9 +14,7 @@ metadata:
 {{ toYaml . | indent 4 }}
   {{- end }}
 automountServiceAccountToken: false
-
 ---
-
 apiVersion: v1
 kind: Secret
 metadata:
@@ -28,9 +27,7 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: rad-sbom
 type: kubernetes.io/service-account-token
-
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -45,46 +42,7 @@ rules:
     resources: ["configmaps"]
     resourceNames: [ "rad-sbom-dynamic-configuration" ]
     verbs: ["get", "list", "watch"]
-
 ---
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: rad-sbom
-  labels:
-    app_name: rad-sbom
-    app_version: {{ .Values.sbom.image.tag | quote }}
-    maintained_by: rad.security
-rules:
-  - apiGroups: [""]
-    resources: ["namespaces", "pods"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get"]
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: rad-sbom
-  labels:
-    app_name: rad-sbom
-    app_version: {{ .Values.sbom.image.tag | quote }}
-    maintained_by: rad.security
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: rad-sbom
-subjects:
-  - kind: ServiceAccount
-    name: rad-sbom
-    namespace: {{ .Release.Namespace }}
-
----
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -102,9 +60,7 @@ subjects:
   - kind: ServiceAccount
     name: rad-sbom
     namespace: {{ .Release.Namespace }}
-
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -122,6 +78,42 @@ subjects:
 - kind: ServiceAccount
   name: rad-sbom
   namespace: {{ .Release.Namespace }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rad-sbom
+  labels:
+    app_name: rad-sbom
+    app_version: {{ .Values.sbom.image.tag | quote }}
+    maintained_by: rad.security
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces", "pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+---
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rad-sbom
+  labels:
+    app_name: rad-sbom
+    app_version: {{ .Values.sbom.image.tag | quote }}
+    maintained_by: rad.security
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rad-sbom
+subjects:
+  - kind: ServiceAccount
+    name: rad-sbom
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 
 ---
 
@@ -140,11 +132,10 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rad-sbom
-  namespace: system
+  namespace: {{ .Release.Namespace }}
 
 ---
-
-{{ if ( eq .Values.eksAddon.enabled false ) }}
+{{- if and ( eq .Values.eksAddon.enabled false ) ( eq (include "rad-plugins.deployInKubeSystem" .) "true" ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -161,8 +152,5 @@ subjects:
   - kind: ServiceAccount
     name: rad-sbom
     namespace: {{ .Release.Namespace }}
-
----
-
 {{- end }}
 {{- end }}

--- a/stable/rad-plugins/templates/sbom/service.yaml
+++ b/stable/rad-plugins/templates/sbom/service.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.sbom.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,4 +18,5 @@ spec:
     app_name: rad-sbom
     app_version: {{ .Values.sbom.image.tag | quote }}
     maintained_by: rad.security
+{{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/sync/deployment.yaml
+++ b/stable/rad-plugins/templates/sync/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.sync.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -105,4 +106,5 @@ spec:
       - name: api-token
         secret:
           secretName: rad-sync-api-token-secret
+{{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/sync/dynamic-config.yaml
+++ b/stable/rad-plugins/templates/sync/dynamic-config.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.sync.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,3 +12,6 @@ metadata:
 data:
 # Placeholder for dynamic configuration created via rad-sync
 # Main purpose of this ConfigMap is to delete it when rad-plugins helm chart is uninstalled
+  config: "{}"
+{{- end -}}
+{{- end -}}

--- a/stable/rad-plugins/templates/sync/rbac.yaml
+++ b/stable/rad-plugins/templates/sync/rbac.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.sync.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -13,9 +14,7 @@ metadata:
 {{ toYaml . | indent 4 }}
   {{- end }}
 automountServiceAccountToken: false
-
 ---
-
 apiVersion: v1
 kind: Secret
 metadata:
@@ -28,9 +27,7 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: rad-sync
 type: kubernetes.io/service-account-token
-
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -45,9 +42,26 @@ rules:
     resources: ["configmaps"]
     resourceNames: [ "rad-guard-dynamic-configuration", "rad-sbom-dynamic-configuration", "rad-sync-dynamic-configuration", "rad-watch-dynamic-configuration", "rad-runtime-dynamic-configuration", "rad-runtime-exporter-dynamic-configuration" ]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-
 ---
-
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rad-sync-configmap-mutator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app_name: rad-sync
+    app_version: {{ .Values.sync.image.tag | quote }}
+    maintained_by: rad.security
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rad-sync-configmap-mutator
+subjects:
+  - kind: ServiceAccount
+    name: rad-sync
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -60,9 +74,8 @@ rules:
   - apiGroups: [ "ksoc.com" ]
     resources: [ "guardpolicies" ]
     verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
-
 ---
-
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -79,30 +92,9 @@ subjects:
   - kind: ServiceAccount
     name: rad-sync
     namespace: {{ .Release.Namespace }}
-
+{{- end }}
 ---
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: rad-sync-configmap-mutator
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app_name: rad-sync
-    app_version: {{ .Values.sync.image.tag | quote }}
-    maintained_by: rad.security
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: rad-sync-configmap-mutator
-subjects:
-  - kind: ServiceAccount
-    name: rad-sync
-    namespace: {{ .Release.Namespace }}
-
----
-
-{{ if ( eq .Values.eksAddon.enabled false ) -}}
+{{- if and ( eq .Values.eksAddon.enabled false ) ( eq (include "rad-plugins.deployInKubeSystem" .) "true" ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -119,8 +111,5 @@ subjects:
   - kind: ServiceAccount
     name: rad-sync
     namespace: {{ .Release.Namespace }}
-
----
-
 {{- end }}
 {{- end }}

--- a/stable/rad-plugins/templates/watch/custom-resource-rules.yaml
+++ b/stable/rad-plugins/templates/watch/custom-resource-rules.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.watch.enabled .Values.watch.ingestCustomResources -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,5 +11,6 @@ metadata:
     maintained_by: rad.security
 data:
   rules.yaml: |
-  {{- .Values.watch.customResourceRules | toYaml | nindent 4 }}
+    {{- .Values.watch.customResourceRules | toYaml | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/watch/deployment.yaml
+++ b/stable/rad-plugins/templates/watch/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.watch.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,6 +35,11 @@ spec:
 {{ toYaml . | indent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: rad-watch
+      {{- if .Values.workloads.imagePullSecretName }}
+      imagePullSecrets:
+        - name: {{ .Values.workloads.imagePullSecretName }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
@@ -43,11 +49,6 @@ spec:
           type: RuntimeDefault
       {{- end }}
       automountServiceAccountToken: false
-      serviceAccountName: rad-watch
-      {{- if .Values.workloads.imagePullSecretName }}
-      imagePullSecrets:
-        - name: {{ .Values.workloads.imagePullSecretName }}
-      {{- end }}
       initContainers:
 {{ include "rad-plugins.bootstrap-initcontainer" . | indent 8 }}
       containers:
@@ -87,7 +88,7 @@ spec:
             - name: INGEST_CUSTOM_RESOURCES
               value: "true"
             - name: CUSTOM_RESOURCE_RULES_PATH
-              value: /var/run/custom-resource-rules/rules.yaml
+              value: "/var/run/custom-resource-rules/rules.yaml"
             {{- end }}
             {{- range $key, $value := .Values.watch.env }}
             - name: "{{ $key }}"
@@ -121,4 +122,5 @@ spec:
         configMap:
           name: rad-watch-custom-resource-rules
       {{- end }}
+{{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/watch/dynamic-config.yaml
+++ b/stable/rad-plugins/templates/watch/dynamic-config.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.watch.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,3 +12,6 @@ metadata:
 data:
 # Placeholder for dynamic configuration created via rad-sync
 # Main purpose of this ConfigMap is to delete it when rad-plugins helm chart is uninstalled
+  config: "{}"
+{{- end -}}
+{{- end -}}

--- a/stable/rad-plugins/templates/watch/rbac.yaml
+++ b/stable/rad-plugins/templates/watch/rbac.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.watch.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -13,9 +14,7 @@ metadata:
 {{ toYaml . | indent 4 }}
   {{- end }}
 automountServiceAccountToken: false
-
 ---
-
 apiVersion: v1
 kind: Secret
 metadata:
@@ -28,9 +27,7 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: rad-watch
 type: kubernetes.io/service-account-token
-
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -43,61 +40,9 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: [ "rad-watch-dynamic-configuration" ]
+    resourceNames: [ "rad-watch-dynamic-configuration", "rad-watch-custom-resource-rules" ]
     verbs: ["get", "list", "watch"]
-
 ---
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: rad-watch
-  labels:
-    app_name: rad-watch
-    app_version: {{ .Values.watch.image.tag | quote }}
-    maintained_by: rad.security
-rules:
-  - apiGroups: [""]
-    resources: ["configmaps", "namespaces", "nodes", "pods", "services", "serviceaccounts"]
-    verbs: ["get", "list", "watch"]
-
-  - apiGroups: [ "apps" ]
-    resources: [ "daemonsets", "deployments", "replicasets", "statefulsets"]
-    verbs: [ "get", "list", "watch" ]
-
-  - apiGroups: [ "batch" ]
-    resources: [ "cronjobs", "jobs"]
-    verbs: [ "get", "list", "watch" ]
-
-  - apiGroups: [ "discovery.k8s.io" ]
-    resources: [ "endpointslices" ]
-    verbs: [ "get", "list", "watch" ]
-
-  - apiGroups: [ "rbac.authorization.k8s.io" ]
-    resources: [ "clusterrolebindings", "clusterroles", "rolebindings", "roles" ]
-    verbs: [ "get", "list", "watch" ]
-
-  - apiGroups: [ "ksoc.com" ]
-    resources: [ "guardpolicies", "guardresults" ]
-    verbs: [ "get", "list", "watch" ]
-
-  - apiGroups: [ "networking.k8s.io" ]
-    resources: [ "ingresses", "networkpolicies" ]
-    verbs: [ "get", "list", "watch" ]
-
-  - apiGroups: [ "apiextensions.k8s.io" ]
-    resources: [ "customresourcedefinitions" ]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-
-  {{- if .Values.watch.ingestCustomResources }}
-  {{ range .Values.watch.customResourceRules.allowlist }}
-  - apiGroups: {{ .apiGroups | toJson }}
-    resources: {{ .resources | toJson }}
-    verbs: [ "get", "list", "watch" ]
-  {{ end }}
-  {{- end }}
----
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -115,9 +60,58 @@ subjects:
   - kind: ServiceAccount
     name: rad-watch
     namespace: {{ .Release.Namespace }}
-
 ---
-
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rad-watch-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app_name: rad-watch
+    app_version: {{ .Values.watch.image.tag | quote }}
+    maintained_by: rad.security
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rad-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: rad-watch
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rad-watch
+  labels:
+    app_name: rad-watch
+    app_version: {{ .Values.watch.image.tag | quote }}
+    maintained_by: rad.security
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "namespaces", "nodes", "pods", "services", "serviceaccounts"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: [ "daemonsets", "deployments", "replicasets", "statefulsets" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "batch" ]
+    resources: [ "cronjobs", "jobs" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "networking.k8s.io", "extensions" ]
+    resources: [ "networkpolicies", "ingresses" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "ksoc.com" ]
+    resources: [ "guardpolicies", "guardresults" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: [ "customresourcedefinitions" ]
+    verbs: [ "get", "list", "watch" ]
+---
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -134,10 +128,9 @@ subjects:
   - kind: ServiceAccount
     name: rad-watch
     namespace: {{ .Release.Namespace }}
-
+{{- end }}
 ---
-
-{{ if ( eq .Values.eksAddon.enabled false ) }}
+{{- if and ( eq .Values.eksAddon.enabled false ) ( eq (include "rad-plugins.deployInKubeSystem" .) "true" ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -154,8 +147,5 @@ subjects:
   - kind: ServiceAccount
     name: rad-watch
     namespace: {{ .Release.Namespace }}
-
----
-
 {{- end }}
 {{- end }}

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -20,11 +20,11 @@ rad:
     enabled: true
   # -- Control which namespaces to deploy resources to
   deployment:
-    # -- Deploy resources in the release namespace (the namespace where the chart is installed)
-    # If false, no resources will be deployed in the release namespace
+    # -- Deploy resources in the release namespace (the namespace where the chart is installed).
+    # If false, no resources will be deployed in the release namespace.
     releaseNamespace: true
-    # -- Deploy resources in the kube-system namespace
-    # If false, no resources will be deployed in the kube-system namespace
+    # -- Deploy resources in the kube-system namespace.
+    # If false, no resources will be deployed in the kube-system namespace.
     kubeSystem: true
 
 workloads:

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -18,6 +18,14 @@ rad:
   # -- Enable seccompProfile for all RAD Security pods
   seccompProfile:
     enabled: true
+  # -- Control which namespaces to deploy resources to
+  deployment:
+    # -- Deploy resources in the release namespace (the namespace where the chart is installed)
+    # If false, no resources will be deployed in the release namespace
+    releaseNamespace: true
+    # -- Deploy resources in the kube-system namespace
+    # If false, no resources will be deployed in the kube-system namespace
+    kubeSystem: true
 
 workloads:
   # -- Whether to disable service mesh integration.


### PR DESCRIPTION
#### What this PR does / why we need it
This PR adds the ability to deploy RAD Security components to different namespaces based on configuration, giving users more flexibility in how they structure their deployments.
Changes:
- Added new configuration flags in values.yaml:
```yaml
rad:
  deployment:
    releaseNamespace: true  # Deploy resources in the release namespace
    kubeSystem: true        # Deploy resources in the kube-system namespace
```
- Modified templates to conditionally deploy resources to namespaces based on these flags
- Added documentation to README.md.gotmpl and CONTRIBUTING.md explaining the namespace-based deployment
- Created new GitHub workflow for testing namespace deployment scenarios
- Updated existing CI workflow to include tests for namespace-based deployment

Usage:
Users can now:
- Deploy to both namespaces (default)
- Deploy only to the release namespace: --set rad.deployment.kubeSystem=false
- Deploy only to kube-system: --set rad.deployment.releaseNamespace=false

Testing:
Verified the functionality with comprehensive tests that check if resources are correctly deployed to the intended namespaces based on configuration flags. All linting and rendering tests pass successfully.


#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
