### PR TITLE
Patch yaml separator issues under different configs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,6 +129,22 @@ jobs:
           # when running the test. This is expected behavior when .Release.Namespace resolves to "default"
           # during the helm template command.
 
+          # Test no namespace deployment
+          mkdir -p test-output-no-namespaces
+          helm template stable/rad-plugins \
+            --set runtime.enabled=true \
+            --set rad.deployment.releaseNamespace=false \
+            --set rad.deployment.kubeSystem=false \
+            --output-dir test-output-no-namespaces
+          file_count=$(find test-output-no-namespaces -name "*.yaml" -type f -not -empty | wc -l)
+          echo "No namespaces configuration file count: $file_count"
+          if [ "$file_count" -gt 0 ]; then
+            echo "Rendered files:"
+            find test-output-no-namespaces -name "*.yaml" -type f -not -empty -exec ls -la {} \;
+            echo "❌ Resources were rendered when both namespace flags are disabled"
+            exit 1
+          fi
+
           # Test PII analyzer
           helm template stable/rad-plugins \
             --set runtime.enabled=true \
@@ -138,6 +154,27 @@ jobs:
             --output-dir test-output-pii
           if [ -f test-output-pii/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml ]; then
             echo "❌ PII analyzer still rendered when release namespace is disabled"
+            exit 1
+          fi
+
+          # Test backward compatibility with nil rad.deployment
+          cat > backward-compat-values.yaml << EOF
+          runtime:
+            enabled: true
+          EOF
+
+          mkdir -p test-output-backward-compat
+          helm template stable/rad-plugins -f backward-compat-values.yaml \
+            --output-dir test-output-backward-compat
+
+          # Verify resources are deployed to both namespaces (default behavior)
+          if ! grep -q "namespace:" test-output-backward-compat/rad-plugins/templates/guard/deployment.yaml; then
+            echo "❌ Backward compatibility test failed: missing deployments in release namespace"
+            exit 1
+          fi
+
+          if ! grep -q "namespace: kube-system" test-output-backward-compat/rad-plugins/templates/rbac.yaml; then
+            echo "❌ Backward compatibility test failed: missing resources in kube-system namespace"
             exit 1
           fi
 

--- a/.github/workflows/test-namespace-deployment.yaml
+++ b/.github/workflows/test-namespace-deployment.yaml
@@ -106,6 +106,32 @@ jobs:
 
           echo "✅ Kube-system namespace only configuration test passed"
 
+      - name: Test no namespace deployment
+        run: |
+          # Create test directory
+          mkdir -p test-output-no-namespaces
+
+          # Run template with both flags set to false
+          helm template stable/rad-plugins \
+            --set runtime.enabled=true \
+            --set rad.deployment.releaseNamespace=false \
+            --set rad.deployment.kubeSystem=false \
+            --output-dir test-output-no-namespaces
+
+          # Count rendered files
+          file_count=$(find test-output-no-namespaces -name "*.yaml" -type f -not -empty | wc -l)
+          echo "No namespaces configuration file count: $file_count"
+
+          # Check if any resources were rendered
+          if [ "$file_count" -gt 0 ]; then
+            echo "Rendered files:"
+            find test-output-no-namespaces -name "*.yaml" -type f -not -empty -exec ls -la {} \;
+            echo "❌ Resources were rendered when both namespace flags are disabled"
+            exit 1
+          fi
+
+          echo "✅ No namespace deployment test passed"
+
       - name: Test runtime PII analyzer
         run: |
           # Test with both namespaces (default)
@@ -136,6 +162,36 @@ jobs:
           fi
 
           echo "✅ PII analyzer test passed"
+
+      - name: Test backward compatibility
+        run: |
+          # Create a values file that doesn't include rad.deployment to simulate an upgrade scenario
+          cat > backward-compat-values.yaml << EOF
+          runtime:
+            enabled: true
+          EOF
+
+          # Create test directory
+          mkdir -p test-output-backward-compat
+
+          # Test with values file that doesn't specify rad.deployment
+          helm template stable/rad-plugins -f backward-compat-values.yaml \
+            --output-dir test-output-backward-compat
+
+          # Verify resources are deployed to both namespaces (default behavior)
+          # 1. Check release namespace resources
+          if ! grep -q "namespace:" test-output-backward-compat/rad-plugins/templates/guard/deployment.yaml; then
+            echo "❌ Backward compatibility test failed: missing deployments in release namespace"
+            exit 1
+          fi
+
+          # 2. Check kube-system namespace resources
+          if ! grep -q "namespace: kube-system" test-output-backward-compat/rad-plugins/templates/rbac.yaml; then
+            echo "❌ Backward compatibility test failed: missing resources in kube-system namespace"
+            exit 1
+          fi
+
+          echo "✅ Backward compatibility test passed"
 
       - name: Report success
         if: success()

--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.3.0
+version: 2.3.1
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/favicon.ico
@@ -17,8 +17,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: added
-      description: Added config to enable separate helm ops by namespace
+    - kind: fixed
+      description: Added handling for helm upgrade that lacks rad.deployment in values.yaml
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/templates/cert-manager-issuer.yaml
+++ b/stable/rad-plugins/templates/cert-manager-issuer.yaml
@@ -1,3 +1,4 @@
+{{- if ne (include "rad-plugins.deployInReleaseNamespace" .) "false" -}}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -7,3 +8,4 @@ metadata:
     maintained_by: rad.security
 spec:
   selfSigned: {}
+{{- end -}}

--- a/stable/rad-plugins/templates/guard/rbac.yaml
+++ b/stable/rad-plugins/templates/guard/rbac.yaml
@@ -89,6 +89,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 {{- end }}
 
+{{- if or (eq (include "rad-plugins.deployInReleaseNamespace" .) "true") (eq (include "rad-plugins.deployInKubeSystem" .) "true") }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -112,10 +113,11 @@ rules:
   - apiGroups: [ "ksoc.com" ]
     resources: [ "guardpolicies/status", "guardresults/status" ]
     verbs: [ "get" ]
-
----
+{{- end }}
 
 {{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -134,6 +136,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 {{- end }}
 
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -152,10 +155,11 @@ subjects:
   - kind: ServiceAccount
     name: rad-guard
     namespace: {{ .Release.Namespace }}
-
----
+{{- end }}
 
 {{- if and ( eq .Values.eksAddon.enabled false ) ( eq (include "rad-plugins.deployInKubeSystem" .) "true" ) }}
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/stable/rad-plugins/templates/rbac.yaml
+++ b/stable/rad-plugins/templates/rbac.yaml
@@ -42,6 +42,7 @@ rules:
       - patch
 {{- end }}
 
+{{- if or (eq (include "rad-plugins.deployInReleaseNamespace" .) "true") (eq (include "rad-plugins.deployInKubeSystem" .) "true") }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -63,10 +64,11 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
-
----
+{{- end }}
 
 {{- if and ( eq .Values.eksAddon.enabled false ) ( eq (include "rad-plugins.deployInKubeSystem" .) "true" ) }}
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/stable/rad-plugins/templates/runtime/rbac.yaml
+++ b/stable/rad-plugins/templates/runtime/rbac.yaml
@@ -66,8 +66,9 @@ subjects:
   - kind: ServiceAccount
     name: rad-runtime
     namespace: {{ .Release.Namespace }}
-{{- end -}}
+{{- end }}
 
+{{- if or (eq (include "rad-plugins.deployInReleaseNamespace" .) "true") (eq (include "rad-plugins.deployInKubeSystem" .) "true") }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,10 +91,11 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps", "pods", "nodes", "services"]
     verbs: ["get", "watch", "list" ]
+{{- end }}
 
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 ---
 
-{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -110,11 +112,11 @@ subjects:
   - kind: ServiceAccount
     name: rad-runtime
     namespace: {{ .Release.Namespace }}
-{{- end -}}
-
----
+{{- end }}
 
 {{- if and ( eq .Values.eksAddon.enabled false ) ( eq (include "rad-plugins.deployInKubeSystem" .) "true" ) }}
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/stable/rad-plugins/templates/sbom/rbac.yaml
+++ b/stable/rad-plugins/templates/sbom/rbac.yaml
@@ -79,6 +79,8 @@ subjects:
   name: rad-sbom
   namespace: {{ .Release.Namespace }}
 {{- end }}
+
+{{- if or (eq (include "rad-plugins.deployInReleaseNamespace" .) "true") (eq (include "rad-plugins.deployInKubeSystem" .) "true") }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -95,8 +97,10 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get"]
----
+{{- end }}
+
 {{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -115,8 +119,8 @@ subjects:
     namespace: {{ .Release.Namespace }}
 {{- end }}
 
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -133,9 +137,10 @@ subjects:
 - kind: ServiceAccount
   name: rad-sbom
   namespace: {{ .Release.Namespace }}
+{{- end }}
 
----
 {{- if and ( eq .Values.eksAddon.enabled false ) ( eq (include "rad-plugins.deployInKubeSystem" .) "true" ) }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/stable/rad-plugins/templates/sync/rbac.yaml
+++ b/stable/rad-plugins/templates/sync/rbac.yaml
@@ -61,6 +61,8 @@ subjects:
     name: rad-sync
     namespace: {{ .Release.Namespace }}
 {{- end }}
+
+{{- if or (eq (include "rad-plugins.deployInReleaseNamespace" .) "true") (eq (include "rad-plugins.deployInKubeSystem" .) "true") }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -74,8 +76,10 @@ rules:
   - apiGroups: [ "ksoc.com" ]
     resources: [ "guardpolicies" ]
     verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
----
+{{- end }}
+
 {{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -93,8 +97,9 @@ subjects:
     name: rad-sync
     namespace: {{ .Release.Namespace }}
 {{- end }}
----
+
 {{- if and ( eq .Values.eksAddon.enabled false ) ( eq (include "rad-plugins.deployInKubeSystem" .) "true" ) }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/stable/rad-plugins/templates/watch/rbac.yaml
+++ b/stable/rad-plugins/templates/watch/rbac.yaml
@@ -79,6 +79,8 @@ subjects:
     name: rad-watch
     namespace: {{ .Release.Namespace }}
 {{- end }}
+
+{{- if or (eq (include "rad-plugins.deployInReleaseNamespace" .) "true") (eq (include "rad-plugins.deployInKubeSystem" .) "true") }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -110,8 +112,10 @@ rules:
   - apiGroups: [ "apiextensions.k8s.io" ]
     resources: [ "customresourcedefinitions" ]
     verbs: [ "get", "list", "watch" ]
----
+{{- end }}
+
 {{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -129,8 +133,9 @@ subjects:
     name: rad-watch
     namespace: {{ .Release.Namespace }}
 {{- end }}
----
+
 {{- if and ( eq .Values.eksAddon.enabled false ) ( eq (include "rad-plugins.deployInKubeSystem" .) "true" ) }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it
This PR addresses backward compatibility concerns and fixes edge cases in the namespace-based deployment implementation:
- Fixed YAML document separator issues in the runtime/rbac.yaml template that caused rendering errors
- Corrected conditional logic in cert-manager-issuer.yaml template to properly handle when both deployment flags are set to false
- Added backwards compatibility tests to verify resources deploy correctly when `rad.deployment` is undefined (upgrade scenario)
- Ensured nil value handling in helper templates defaults both namespace flags to true when `rad.deployment` object is missing
- Extended CI tests to verify no resources render when both namespace flags are explicitly set to false

These changes maintain backward compatibility for existing deployments while providing flexibility to control which namespaces resources are deployed to. All tests now pass, including edge cases and upgrade scenarios.

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
