### PR TITLE
Restore missing permissions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,21 @@ When adding new resources to the chart, you must ensure they respect this namesp
 
 * For cluster-wide resources (ClusterRoles, ClusterRoleBindings, etc.), determine if they should be conditionally rendered based on their purpose and associated namespaced resources.
 
+### RBAC Permissions for CustomResourceDefinitions
+
+Multiple components in this chart (guard, watch, sync) require permissions to manage CustomResourceDefinitions (CRDs):
+
+* Components that need to create, update, or patch CRDs must have appropriate ClusterRole permissions:
+  ```yaml
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  ```
+
+* These permissions are required even when using namespace-based deployment, as CRDs are cluster-scoped resources.
+
+* Always ensure these permissions exist in the ClusterRoles for components that interact with CRDs.
+
 This separation allows users to deploy resources selectively by namespace, which is important for organizations with different teams managing different namespaces.
 
 ### Testing Namespace-Based Deployment

--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.3.1
+version: 2.3.2
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/favicon.ico
@@ -18,7 +18,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: fixed
-      description: Added handling for helm upgrade that lacks rad.deployment in values.yaml
+      description: Fix RBAC permissions for watch and sync plugins
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/templates/sync/rbac.yaml
+++ b/stable/rad-plugins/templates/sync/rbac.yaml
@@ -76,6 +76,9 @@ rules:
   - apiGroups: [ "ksoc.com" ]
     resources: [ "guardpolicies" ]
     verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: [ "customresourcedefinitions" ]
+    verbs: [ "get", "list", "watch", "create", "update", "patch" ]
 {{- end }}
 
 {{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}

--- a/stable/rad-plugins/templates/watch/rbac.yaml
+++ b/stable/rad-plugins/templates/watch/rbac.yaml
@@ -106,12 +106,15 @@ rules:
   - apiGroups: [ "networking.k8s.io", "extensions" ]
     resources: [ "networkpolicies", "ingresses" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "discovery.k8s.io" ]
+    resources: [ "endpointslices" ]
+    verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "ksoc.com" ]
     resources: [ "guardpolicies", "guardresults" ]
     verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "apiextensions.k8s.io" ]
     resources: [ "customresourcedefinitions" ]
-    verbs: [ "get", "list", "watch" ]
+    verbs: [ "get", "list", "watch", "create", "update", "patch" ]
 {{- end }}
 
 {{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}


### PR DESCRIPTION
#### What this PR does / why we need it
This PR addresses critical issues with namespace-based deployment RBAC that were causing components to fail:

Changes:
1. Fixed missing CRD permissions:
  - Added create, update, and patch permissions for rad-watch to manage CustomResourceDefinitions
  - Added complete CRD permissions for rad-sync which was missing these permissions entirely
  - Restored discovery.k8s.io permissions for the watch component, which were inadvertently removed
2. Updated documentation:
  - Added a new section to CONTRIBUTING.md explaining the importance of preserving RBAC permissions
  - Documented that cluster-scoped permissions are required even when using namespace-based deployment

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
