### PR TITLE
Fix indentation for seccompProfile and safely default resources for p…

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.3.3
+version: 2.3.4
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/favicon.ico
@@ -18,7 +18,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fix hardcoded namespace for pii-analyzer. Add improved logging
+      description: Fixed indentation for seccomp profile
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml
+++ b/stable/rad-plugins/templates/runtime/pii-analyzer-deployment.yaml
@@ -38,10 +38,10 @@ spec:
       serviceAccountName: rad-pii-analyzer
       automountServiceAccountToken: false
       securityContext:
-      {{- if .Values.rad.seccompProfile.enabled }}
+{{- if .Values.rad.seccompProfile.enabled }}
         seccompProfile:
           type: RuntimeDefault
-      {{- end }}
+{{- end }}
       containers:
       - name: rad-pii-analyzer
         image: {{ .Values.runtime.piiAnalyzer.image.repository }}:{{ .Values.runtime.piiAnalyzer.image.tag }}
@@ -50,21 +50,21 @@ spec:
         - containerPort: 8080
         resources:
           requests:
-            memory: {{ .Values.runtime.piiAnalyzer.resources.requests.memory }}
-            cpu: {{ .Values.runtime.piiAnalyzer.resources.requests.cpu }}
+            memory: {{ default "128Mi" .Values.runtime.piiAnalyzer.resources.requests.memory }}
+            cpu: {{ default "100m" .Values.runtime.piiAnalyzer.resources.requests.cpu }}
           limits:
-            memory: {{ .Values.runtime.piiAnalyzer.resources.limits.memory }}
-            cpu: {{ .Values.runtime.piiAnalyzer.resources.limits.cpu }}
+            memory: {{ default "2Gi" .Values.runtime.piiAnalyzer.resources.limits.memory }}
+            cpu: {{ default "1000m" .Values.runtime.piiAnalyzer.resources.limits.cpu }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
               - ALL
           privileged: false
-      {{- if .Values.rad.seccompProfile.enabled }}
-        seccompProfile:
-          type: RuntimeDefault
-      {{- end }}
+{{- if .Values.rad.seccompProfile.enabled }}
+          seccompProfile:
+            type: RuntimeDefault
+{{- end }}
         env:
           - name: PORT
             value: "8080"


### PR DESCRIPTION
#### What this PR does / why we need it
This PR addresses two issues with the PII analyzer deployment:
- Fixed indentation of seccompProfile conditionals:
  - Corrected the indentation at both pod and container levels
  - Ensured conditional blocks `{{- if .Values.rad.seccompProfile.enabled }}` are properly aligned
  - Fixed inconsistent spacing that could cause rendering issues
- Added default resource constraints for backward compatibility:
```yaml
    resources:
       requests:
         memory: {{ default "128Mi" .Values.runtime.piiAnalyzer.resources.requests.memory }}
         cpu: {{ default "100m" .Values.runtime.piiAnalyzer.resources.requests.cpu }}
       limits:
         memory: {{ default "2Gi" .Values.runtime.piiAnalyzer.resources.limits.memory }}
         cpu: {{ default "1000m" .Values.runtime.piiAnalyzer.resources.limits.cpu }}
```
  - Added sensible defaults for resource requests and limits:
    - Ensures that even with an old values.yaml file that doesn't define PII analyzer resources, the deployment will have appropriate constraints
    - Prevents unbound resource consumption and potential OOM issues during upgrades


#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
