### PR TITLE
Only deploy the guard ClusterRole when deployInReleaseNamespace enabled

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,12 @@ jobs:
             exit 1
           fi
 
+          # Verify guard ClusterRole does NOT exist when only kube-system namespace is enabled
+          if grep -q "kind: ClusterRole" test-output-kube-system-only/rad-plugins/templates/guard/rbac.yaml | grep -q "name: rad-guard"; then
+            echo "❌ Kube-system namespace only configuration still has guard ClusterRole which should only be deployed with release namespace"
+            exit 1
+          fi
+
           # NOTE: We don't check subjects in bindings since they will reference ServiceAccounts in the default namespace
           # when running the test. This is expected behavior when .Release.Namespace resolves to "default"
           # during the helm template command.

--- a/.github/workflows/test-namespace-deployment.yaml
+++ b/.github/workflows/test-namespace-deployment.yaml
@@ -90,13 +90,9 @@ jobs:
             exit 1
           fi
 
-          # Verify ClusterRoles still exist (they're not namespace-specific)
-          found_cluster_role=false
-          if grep -q "kind: ClusterRole" test-output-kube-system-only/rad-plugins/templates/guard/rbac.yaml; then
-            found_cluster_role=true
-          fi
-          if [ "$found_cluster_role" != "true" ]; then
-            echo "❌ Kube-system namespace only configuration missing cluster roles"
+          # Verify guard ClusterRole does NOT exist when only kube-system namespace is enabled
+          if grep -q "kind: ClusterRole" test-output-kube-system-only/rad-plugins/templates/guard/rbac.yaml | grep -q "name: rad-guard"; then
+            echo "❌ Kube-system namespace only configuration still has guard ClusterRole which should only be deployed with release namespace"
             exit 1
           fi
 

--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -17,8 +17,6 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fixed indentation for seccomp profile
     - kind: changed
       description: ClusterRole for guard now only deploys when release namespace is enabled
   artifacthub.io/containsSecurityUpdates: "false"

--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.3.4
+version: 2.3.5
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/favicon.ico
@@ -19,6 +19,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: fixed
       description: Fixed indentation for seccomp profile
+    - kind: changed
+      description: ClusterRole for guard now only deploys when release namespace is enabled
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/templates/guard/rbac.yaml
+++ b/stable/rad-plugins/templates/guard/rbac.yaml
@@ -89,7 +89,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 {{- end }}
 
-{{- if or (eq (include "rad-plugins.deployInReleaseNamespace" .) "true") (eq (include "rad-plugins.deployInKubeSystem" .) "true") }}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
#### What this PR does / why we need it
Updated the ClusterRole conditional in guard/rbac.yaml to only deploy when the release namespace deployment is enabled, instead of deploying when either namespace was enabled.

This change ensures the ClusterRole is only created when resources are deployed to the release namespace, preventing unnecessary RBAC resources when only kube-system deployment is enabled.

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
