### PR TITLE
Deploy all cluster-scoped resources only in default config or when de…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,14 @@ jobs:
 
           # Test default (both namespaces)
           helm template stable/rad-plugins \
+            --set guard.enabled=true \
+            --set sbom.enabled=true \
+            --set sync.enabled=true \
+            --set watch.enabled=true \
             --set runtime.enabled=true \
+            --set runtime.httpTracingEnabled=true \
+            --set runtime.piiAnalyzer.enabled=true \
+            --set priorityClass.enabled=true \
             --output-dir test-output-default
           echo "Default configuration file count: $(find test-output-default -type f | wc -l)"
           if ! grep -q "namespace:" test-output-default/rad-plugins/templates/guard/deployment.yaml; then
@@ -97,7 +104,14 @@ jobs:
 
           # Test release namespace only
           helm template stable/rad-plugins \
+            --set guard.enabled=true \
+            --set sbom.enabled=true \
+            --set sync.enabled=true \
+            --set watch.enabled=true \
             --set runtime.enabled=true \
+            --set runtime.httpTracingEnabled=true \
+            --set runtime.piiAnalyzer.enabled=true \
+            --set priorityClass.enabled=true \
             --set rad.deployment.kubeSystem=false \
             --output-dir test-output-release-only
           if ! grep -q "namespace:" test-output-release-only/rad-plugins/templates/guard/deployment.yaml; then
@@ -111,7 +125,14 @@ jobs:
 
           # Test kube-system namespace only
           helm template stable/rad-plugins \
+            --set guard.enabled=true \
+            --set sbom.enabled=true \
+            --set sync.enabled=true \
+            --set watch.enabled=true \
             --set runtime.enabled=true \
+            --set runtime.httpTracingEnabled=true \
+            --set runtime.piiAnalyzer.enabled=true \
+            --set priorityClass.enabled=true \
             --set rad.deployment.releaseNamespace=false \
             --output-dir test-output-kube-system-only
           if [ -f test-output-kube-system-only/rad-plugins/templates/guard/deployment.yaml ]; then
@@ -125,9 +146,29 @@ jobs:
             exit 1
           fi
 
-          # Verify guard ClusterRole does NOT exist when only kube-system namespace is enabled
-          if grep -q "kind: ClusterRole" test-output-kube-system-only/rad-plugins/templates/guard/rbac.yaml | grep -q "name: rad-guard"; then
-            echo "❌ Kube-system namespace only configuration still has guard ClusterRole which should only be deployed with release namespace"
+          # Verify ClusterRoles for all components are NOT rendered when deployInReleaseNamespace is false
+          for component in "guard" "sbom" "sync" "watch" "runtime"; do
+            if grep -q "kind: ClusterRole" test-output-kube-system-only/rad-plugins/templates/${component}/rbac.yaml 2>/dev/null; then
+              echo "❌ Kube-system namespace only configuration still has ${component} ClusterRole which should only be deployed with release namespace"
+              exit 1
+            fi
+          done
+
+          # Check that rad-proxy-role ClusterRole is not rendered
+          if grep -q "kind: ClusterRole" test-output-kube-system-only/rad-plugins/templates/rbac.yaml 2>/dev/null | grep -q "name: rad-proxy-role"; then
+            echo "❌ Kube-system namespace only configuration still has rad-proxy-role ClusterRole which should only be deployed with release namespace"
+            exit 1
+          fi
+
+          # Verify PriorityClass is not rendered
+          if grep -q "kind: PriorityClass" test-output-kube-system-only/rad-plugins/templates/priorityclass/priorityclass.yaml 2>/dev/null; then
+            echo "❌ Kube-system namespace only configuration still has PriorityClass which should only be deployed with release namespace"
+            exit 1
+          fi
+
+          # Verify no webhook configurations are rendered
+          if grep -q "kind: MutatingWebhookConfiguration\|kind: ValidatingWebhookConfiguration" test-output-kube-system-only/rad-plugins/templates/*/*webhook*.yaml 2>/dev/null; then
+            echo "❌ Kube-system namespace only configuration still has webhook configurations which should only be deployed with release namespace"
             exit 1
           fi
 
@@ -138,7 +179,14 @@ jobs:
           # Test no namespace deployment
           mkdir -p test-output-no-namespaces
           helm template stable/rad-plugins \
+            --set guard.enabled=true \
+            --set sbom.enabled=true \
+            --set sync.enabled=true \
+            --set watch.enabled=true \
             --set runtime.enabled=true \
+            --set runtime.httpTracingEnabled=true \
+            --set runtime.piiAnalyzer.enabled=true \
+            --set priorityClass.enabled=true \
             --set rad.deployment.releaseNamespace=false \
             --set rad.deployment.kubeSystem=false \
             --output-dir test-output-no-namespaces
@@ -165,7 +213,20 @@ jobs:
 
           # Test backward compatibility with nil rad.deployment
           cat > backward-compat-values.yaml << EOF
+          guard:
+            enabled: true
+          sbom:
+            enabled: true
+          sync:
+            enabled: true
+          watch:
+            enabled: true
           runtime:
+            enabled: true
+            httpTracingEnabled: true
+            piiAnalyzer:
+              enabled: true
+          priorityClass:
             enabled: true
           EOF
 

--- a/.github/workflows/test-namespace-deployment.yaml
+++ b/.github/workflows/test-namespace-deployment.yaml
@@ -30,7 +30,14 @@ jobs:
       - name: Test default (both namespaces)
         run: |
           helm template stable/rad-plugins \
+            --set guard.enabled=true \
+            --set sbom.enabled=true \
+            --set sync.enabled=true \
+            --set watch.enabled=true \
             --set runtime.enabled=true \
+            --set runtime.httpTracingEnabled=true \
+            --set runtime.piiAnalyzer.enabled=true \
+            --set priorityClass.enabled=true \
             --output-dir test-output-default
           echo "Default configuration file count: $(find test-output-default -type f | wc -l)"
 
@@ -51,7 +58,14 @@ jobs:
       - name: Test release namespace only
         run: |
           helm template stable/rad-plugins \
+            --set guard.enabled=true \
+            --set sbom.enabled=true \
+            --set sync.enabled=true \
+            --set watch.enabled=true \
             --set runtime.enabled=true \
+            --set runtime.httpTracingEnabled=true \
+            --set runtime.piiAnalyzer.enabled=true \
+            --set priorityClass.enabled=true \
             --set rad.deployment.kubeSystem=false \
             --output-dir test-output-release-only
           echo "Release namespace only configuration file count: $(find test-output-release-only -type f | wc -l)"
@@ -73,7 +87,14 @@ jobs:
       - name: Test kube-system namespace only
         run: |
           helm template stable/rad-plugins \
+            --set guard.enabled=true \
+            --set sbom.enabled=true \
+            --set sync.enabled=true \
+            --set watch.enabled=true \
             --set runtime.enabled=true \
+            --set runtime.httpTracingEnabled=true \
+            --set runtime.piiAnalyzer.enabled=true \
+            --set priorityClass.enabled=true \
             --set rad.deployment.releaseNamespace=false \
             --output-dir test-output-kube-system-only
           echo "Kube-system namespace only configuration file count: $(find test-output-kube-system-only -type f | wc -l)"
@@ -90,9 +111,29 @@ jobs:
             exit 1
           fi
 
-          # Verify guard ClusterRole does NOT exist when only kube-system namespace is enabled
-          if grep -q "kind: ClusterRole" test-output-kube-system-only/rad-plugins/templates/guard/rbac.yaml | grep -q "name: rad-guard"; then
-            echo "❌ Kube-system namespace only configuration still has guard ClusterRole which should only be deployed with release namespace"
+          # Verify ClusterRoles for all components are NOT rendered when deployInReleaseNamespace is false
+          for component in "guard" "sbom" "sync" "watch" "runtime"; do
+            if grep -q "kind: ClusterRole" test-output-kube-system-only/rad-plugins/templates/${component}/rbac.yaml 2>/dev/null; then
+              echo "❌ Kube-system namespace only configuration still has ${component} ClusterRole which should only be deployed with release namespace"
+              exit 1
+            fi
+          done
+
+          # Check that rad-proxy-role ClusterRole is not rendered
+          if grep -q "kind: ClusterRole" test-output-kube-system-only/rad-plugins/templates/rbac.yaml 2>/dev/null | grep -q "name: rad-proxy-role"; then
+            echo "❌ Kube-system namespace only configuration still has rad-proxy-role ClusterRole which should only be deployed with release namespace"
+            exit 1
+          fi
+
+          # Verify PriorityClass is not rendered
+          if grep -q "kind: PriorityClass" test-output-kube-system-only/rad-plugins/templates/priorityclass/priorityclass.yaml 2>/dev/null; then
+            echo "❌ Kube-system namespace only configuration still has PriorityClass which should only be deployed with release namespace"
+            exit 1
+          fi
+
+          # Verify no webhook configurations are rendered
+          if grep -q "kind: MutatingWebhookConfiguration\|kind: ValidatingWebhookConfiguration" test-output-kube-system-only/rad-plugins/templates/*/*webhook*.yaml 2>/dev/null; then
+            echo "❌ Kube-system namespace only configuration still has webhook configurations which should only be deployed with release namespace"
             exit 1
           fi
 
@@ -109,7 +150,14 @@ jobs:
 
           # Run template with both flags set to false
           helm template stable/rad-plugins \
+            --set guard.enabled=true \
+            --set sbom.enabled=true \
+            --set sync.enabled=true \
+            --set watch.enabled=true \
             --set runtime.enabled=true \
+            --set runtime.httpTracingEnabled=true \
+            --set runtime.piiAnalyzer.enabled=true \
+            --set priorityClass.enabled=true \
             --set rad.deployment.releaseNamespace=false \
             --set rad.deployment.kubeSystem=false \
             --output-dir test-output-no-namespaces
@@ -163,7 +211,20 @@ jobs:
         run: |
           # Create a values file that doesn't include rad.deployment to simulate an upgrade scenario
           cat > backward-compat-values.yaml << EOF
+          guard:
+            enabled: true
+          sbom:
+            enabled: true
+          sync:
+            enabled: true
+          watch:
+            enabled: true
           runtime:
+            enabled: true
+            httpTracingEnabled: true
+            piiAnalyzer:
+              enabled: true
+          priorityClass:
             enabled: true
           EOF
 

--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.3.5
+version: 2.3.6
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/favicon.ico
@@ -18,7 +18,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: ClusterRole for guard now only deploys when release namespace is enabled
+      description: All cluster-scoped resources now only deploy when release namespace is enabled
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/templates/priorityclass/priorityclass.yaml
+++ b/stable/rad-plugins/templates/priorityclass/priorityclass.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.priorityClass.enabled -}}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -7,4 +8,5 @@ value: {{ .Values.priorityClass.value | int }}
 preemptionPolicy: {{ .Values.priorityClass.preemptionPolicy }}
 globalDefault: {{ .Values.priorityClass.globalDefault }}
 description: {{ .Values.priorityClass.description }}
+{{- end }}
 {{- end }}

--- a/stable/rad-plugins/templates/rbac.yaml
+++ b/stable/rad-plugins/templates/rbac.yaml
@@ -42,7 +42,7 @@ rules:
       - patch
 {{- end }}
 
-{{- if or (eq (include "rad-plugins.deployInReleaseNamespace" .) "true") (eq (include "rad-plugins.deployInKubeSystem" .) "true") }}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1

--- a/stable/rad-plugins/templates/runtime/rbac.yaml
+++ b/stable/rad-plugins/templates/runtime/rbac.yaml
@@ -68,7 +68,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 {{- end }}
 
-{{- if or (eq (include "rad-plugins.deployInReleaseNamespace" .) "true") (eq (include "rad-plugins.deployInKubeSystem" .) "true") }}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1

--- a/stable/rad-plugins/templates/sbom/rbac.yaml
+++ b/stable/rad-plugins/templates/sbom/rbac.yaml
@@ -80,7 +80,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 {{- end }}
 
-{{- if or (eq (include "rad-plugins.deployInReleaseNamespace" .) "true") (eq (include "rad-plugins.deployInKubeSystem" .) "true") }}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/stable/rad-plugins/templates/sync/rbac.yaml
+++ b/stable/rad-plugins/templates/sync/rbac.yaml
@@ -62,7 +62,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 {{- end }}
 
-{{- if or (eq (include "rad-plugins.deployInReleaseNamespace" .) "true") (eq (include "rad-plugins.deployInKubeSystem" .) "true") }}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/stable/rad-plugins/templates/watch/rbac.yaml
+++ b/stable/rad-plugins/templates/watch/rbac.yaml
@@ -80,7 +80,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 {{- end }}
 
-{{- if or (eq (include "rad-plugins.deployInReleaseNamespace" .) "true") (eq (include "rad-plugins.deployInKubeSystem" .) "true") }}
+{{- if eq (include "rad-plugins.deployInReleaseNamespace" .) "true" }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
#### What this PR does / why we need it
This PR updates all cluster-scoped resources to only be deployed when deployInReleaseNamespace is set to true, consistent with the existing pattern in the guard component.

Changes:
- Updated ClusterRole condition in templates for sync, sbom, watch, runtime, and rbac components
- Updated PriorityClass to only deploy when deployInReleaseNamespace is true
- Enhanced CI workflows to verify that cluster-scoped resources (ClusterRoles, ClusterRoleBindings, PriorityClass, webhook configurations) are not deployed when deployInReleaseNamespace is false

These changes improve the behavior when running without the release namespace. Previously, some cluster-scoped resources were still deployed when only the kube-system namespace was enabled, even though they wouldn't function properly without corresponding resources in the release namespace.

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
