### PR TITLE
Runtime: Improve secrets filtering

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -18,7 +18,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: Improved Runtime exec event argumets filtering for secrets in Runtime
+      description: Improved Runtime exec event arguments filtering for secrets in Runtime
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.3.6
+version: 2.3.7
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/favicon.ico
@@ -18,7 +18,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: All cluster-scoped resources now only deploy when release namespace is enabled
+      description: Improved Runtime exec event argumets filtering for secrets in Runtime
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -515,7 +515,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | runtime.agent.grpcServerBatchSize | int | `2000` |  |
 | runtime.agent.hostPID | string | `nil` |  |
 | runtime.agent.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-runtime"` |  |
-| runtime.agent.image.tag | string | `"v0.1.22"` |  |
+| runtime.agent.image.tag | string | `"v0.1.23"` |  |
 | runtime.agent.mounts.volumeMounts | list | `[]` |  |
 | runtime.agent.mounts.volumes | list | `[]` |  |
 | runtime.agent.resources.limits.cpu | string | `"200m"` |  |
@@ -528,7 +528,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | runtime.exporter.env.LOG_LEVEL | string | `"INFO"` |  |
 | runtime.exporter.execFilters | list | `[]` | Allows to specify wildcard rules for filtering command arguments. |
 | runtime.exporter.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-runtime-exporter"` |  |
-| runtime.exporter.image.tag | string | `"v0.1.22"` |  |
+| runtime.exporter.image.tag | string | `"v0.1.23"` |  |
 | runtime.exporter.resources.limits.cpu | string | `"500m"` |  |
 | runtime.exporter.resources.limits.ephemeral-storage | string | `"1Gi"` |  |
 | runtime.exporter.resources.limits.memory | string | `"1Gi"` |  |

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -214,7 +214,7 @@ runtime:
         kube-system
     image:
       repository: public.ecr.aws/n8h5y2v5/rad-security/rad-runtime
-      tag: v0.1.22
+      tag: v0.1.23
     resources:
       limits:
         cpu: 200m
@@ -253,7 +253,7 @@ runtime:
 
     image:
       repository: public.ecr.aws/n8h5y2v5/rad-security/rad-runtime-exporter
-      tag: v0.1.22
+      tag: v0.1.23
 
     # -- Allows to specify wildcard rules for filtering command arguments.
     execFilters: []


### PR DESCRIPTION
#### What this PR does / why we need it
This improves exec event argument secrets filtering in Runtime. It adds more common secrets to the list of ones redacted by default.

It also uses `<redacted>` placeholder instead of asterisks `*` to redact secret values before sending to the RAD API as asterisks are heavily used in glob patterns. 

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
