### PR TITLE
Bump rad-sbom to fix issue with refreshing token to Azure ACR

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.3.12
+version: 2.3.13
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/favicon.ico
@@ -17,8 +17,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: added
-      description: Add support for Azure Private Container Registry
+    - kind: fixed
+      description: Fixed issue in rad-sbom with refreshing token for the Azure ACR
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -574,7 +574,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | sbom.env.SBOM_CHECK_LATEST | bool | `false` | Experimental: Whether to check for the latest image in the container registry and generate SBOM for it. If deployed image has tag with semver format, rad-sbom tries to get the newest image, newest minor version, or newest patch version. If the tag is not in semver format, rad-sbom tries to get the newest image from the container registry based on the tag time. Please be aware that time-based algorithm requires many requests to the container registry and may be slow. It works only if credentials are provided. Please note that this feature is experimental and may not work with all container registries. |
 | sbom.env.SBOM_FORMAT | string | `"cyclonedx-json"` | The format of the generated SBOM. Currently we support: syft-json,cyclonedx-json,spdx-json |
 | sbom.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-sbom"` | The image to use for the rad-sbom deployment |
-| sbom.image.tag | string | `"v1.1.46"` |  |
+| sbom.image.tag | string | `"v1.1.47"` |  |
 | sbom.labels | object | `{}` |  |
 | sbom.nodeSelector | object | `{}` |  |
 | sbom.podAnnotations | object | `{}` |  |

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -104,7 +104,7 @@ sbom:
   image:
     # -- The image to use for the rad-sbom deployment
     repository: public.ecr.aws/n8h5y2v5/rad-security/rad-sbom
-    tag: v1.1.46
+    tag: v1.1.47
   env:
     # -- Whether to mutate the image in pod spec by adding digest at the end. By default, digests are added to images to ensure
     # that the image that runs in the cluster matches the digest of the build.  Disable this if your continuous deployment


### PR DESCRIPTION
#### What this PR does / why we need it
When the token becomes invalid, we wrongly refreshed it with Azure ACR. Now it should work as expected

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
