### PR TITLE
Use latest rad-watch to improve memory and network usage. Add minor grammar fix

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.3.13
+version: 2.3.14
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/favicon.ico
@@ -17,8 +17,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fixed issue in rad-sbom with refreshing token for the Azure ACR
+    - kind: changed
+      description: Improved memory and network usage of the rad-watch plugin. Added minor grammar fix to README.
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -42,7 +42,7 @@ To use a private Azure Container Registry, you need to set the `azureWorkloadIde
 
 #### Private ECR Registry
 
-To use a private ECR Registry, you need add and configure proper AWS IAM role with the necessary permissions. For more details see: [Scanning images from ECR](https://docs.rad.security/docs/scanning-images-from-ecr).
+To use a private ECR Registry, you need to add and configure an AWS IAM role with the necessary permissions. For more details see: [Scanning images from ECR](https://docs.rad.security/docs/scanning-images-from-ecr).
 
 ### rad-guard plugin
 
@@ -605,7 +605,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | watch.enabled | bool | `true` |  |
 | watch.env.RECONCILIATION_AT_START | bool | `false` | Whether to trigger reconciliation at startup. |
 | watch.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-watch"` | The image to use for the rad-watch deployment |
-| watch.image.tag | string | `"v1.1.35"` |  |
+| watch.image.tag | string | `"v1.1.36"` |  |
 | watch.ingestCustomResources | bool | `false` | If set will allow ingesting Custom Resources specified in `customResourceRules` |
 | watch.nodeSelector | object | `{}` |  |
 | watch.podAnnotations | object | `{}` |  |

--- a/stable/rad-plugins/README.md.gotmpl
+++ b/stable/rad-plugins/README.md.gotmpl
@@ -42,7 +42,7 @@ To use a private Azure Container Registry, you need to set the `azureWorkloadIde
 
 #### Private ECR Registry
 
-To use a private ECR Registry, you need add and configure proper AWS IAM role with the necessary permissions. For more details see: [Scanning images from ECR](https://docs.rad.security/docs/scanning-images-from-ecr).
+To use a private ECR Registry, you need to add and configure an AWS IAM role with the necessary permissions. For more details see: [Scanning images from ECR](https://docs.rad.security/docs/scanning-images-from-ecr).
 
 ### rad-guard plugin
 

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -172,7 +172,7 @@ watch:
   image:
     # -- The image to use for the rad-watch deployment
     repository: public.ecr.aws/n8h5y2v5/rad-security/rad-watch
-    tag: v1.1.35
+    tag: v1.1.36
   env:
     # -- Whether to trigger reconciliation at startup.
     RECONCILIATION_AT_START: false


### PR DESCRIPTION
#### What this PR does / why we need it
We use the latest rad-watch to reduce the number of events sent to the RAD API by intelligently ignoring insignificant versions, thus reducing the overall egress used.
We also reduce the amount of memory required to run the reconciliation loop.

Finally, we also include a fix kindly provided in https://github.com/rad-security/plugins-helm-chart/pull/49

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
