### PR TITLE
Change pii-analyzer image to support arm64

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.3.24
+version: 2.3.25
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/apple-touch-icon-180x180.png
@@ -17,8 +17,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: security
-      description: Address CVEs in plugins
+    - kind: changed
+      description: Changes pii-analyzer image to custom image to support arm64
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -572,8 +572,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | runtime.nodeSelector | object | `{}` |  |
 | runtime.piiAnalyzer.enabled | bool | `false` |  |
 | runtime.piiAnalyzer.env.LOG_LEVEL | string | `"WARNING"` |  |
-| runtime.piiAnalyzer.image.repository | string | `"mcr.microsoft.com/presidio-analyzer"` |  |
-| runtime.piiAnalyzer.image.tag | string | `"2.2.357"` |  |
+| runtime.piiAnalyzer.image.repository | string | `"public.ecr.aws/n8h5y2v5/presidio-analyzer"` |  |
+| runtime.piiAnalyzer.image.tag | string | `"v0.1.0"` |  |
 | runtime.piiAnalyzer.nodeSelector | object | `{}` |  |
 | runtime.piiAnalyzer.replicas | int | `3` |  |
 | runtime.piiAnalyzer.resources.limits.cpu | string | `"1000m"` |  |

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -278,8 +278,8 @@ runtime:
     env:
       LOG_LEVEL: WARNING
     image:
-      repository: mcr.microsoft.com/presidio-analyzer
-      tag: 2.2.357
+      repository: public.ecr.aws/n8h5y2v5/presidio-analyzer
+      tag: v0.1.0
     nodeSelector: {}
     replicas: 3
     resources:


### PR DESCRIPTION
Adds our own presidio-analyzer image for rad-pii-analyzer since the upstream image does not support arm64.

#### Checklist

- [X] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [X] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [X] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
