### PR TITLE
Adds PVC support for /tmp for all plugins except for presidio and runtimer

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.3.25
+version: 2.3.26
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/apple-touch-icon-180x180.png
@@ -17,8 +17,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: changed
-      description: Changes pii-analyzer image to custom image to support arm64
+    - kind: added
+      description: Adds support for pvc for /tmp mounts in plugins
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -93,7 +93,29 @@ runtime:
 
 Each plugin pod contains `agent` and `exporter` containers. The `agent` container is responsible for collecting runtime information from the nodes in the cluster. The `exporter` container is responsible for exporting the collected information to the RAD Security platform.
 
-The information collected is sent to the RAD Security platform for further processing. For more information on the `rad-runtime
+The information collected is sent to the RAD Security platform for further processing. For more information on the `rad-runtime` plugin, see the [RAD Security documentation](https://docs.rad.security/).
+
+## Persistent Storage
+
+RAD Security plugins support optional persistent storage for enhanced performance and data persistence. When enabled, components use PersistentVolumeClaims (PVCs) as their `/tmp` filesystem instead of ephemeral storage.
+
+### Basic Configuration
+
+Enable persistent storage for any component by setting `PLUGIN_NAME.storage.enabled: true`. If `storageClass` is not set, the default StorageClass will be used.
+
+```yaml
+sbom:
+  storage:
+    enabled: true
+    size: 25Gi
+    storageClass: "gp3" # Define custom storage class
+
+guard:
+  storage:
+    enabled: true
+    size: 1Gi
+    storageClass: ""  # Use default storage class
+```
 
 ## Prerequisites
 
@@ -491,6 +513,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | guard.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | guard.resources.requests.memory | string | `"100Mi"` |  |
 | guard.serviceAccountAnnotations | object | `{}` |  |
+| guard.storage | object | `{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":false,"existingClaim":"","labels":{},"mountPath":"/tmp","selector":{},"size":"1Gi","storageClass":""}` | Storage configuration for rad-guard |
+| guard.storage.accessModes | list | `["ReadWriteOnce"]` | Access modes for the PVC |
+| guard.storage.annotations | object | `{}` | Additional annotations for the PVC |
+| guard.storage.enabled | bool | `false` | Enable persistent storage for rad-guard (used as /tmp filesystem when enabled) |
+| guard.storage.existingClaim | string | `""` | Use existing PVC instead of creating a new one |
+| guard.storage.labels | object | `{}` | Additional labels for the PVC |
+| guard.storage.mountPath | string | `"/tmp"` | Mount path for the persistent volume in the guard container (used as /tmp when enabled) |
+| guard.storage.selector | object | `{}` | Selector for the PV (optional) |
+| guard.storage.size | string | `"1Gi"` | Storage size for guard persistent volume |
+| guard.storage.storageClass | string | `""` | Common classes: gp2/gp3 (AWS), standard-ssd (GKE), managed-premium (AKS) |
 | guard.tolerations | list | `[]` |  |
 | guard.webhook.objectSelector | object | `{}` |  |
 | guard.webhook.timeoutSeconds | int | `10` |  |
@@ -514,6 +546,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | k9.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | k9.resources.requests.memory | string | `"128Mi"` |  |
 | k9.serviceAccountAnnotations | object | `{}` |  |
+| k9.storage | object | `{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":false,"existingClaim":"","labels":{},"mountPath":"/tmp","selector":{},"size":"1Gi","storageClass":""}` | Storage configuration for rad-k9 |
+| k9.storage.accessModes | list | `["ReadWriteOnce"]` | Access modes for the PVC |
+| k9.storage.annotations | object | `{}` | Additional annotations for the PVC |
+| k9.storage.enabled | bool | `false` | Enable persistent storage for rad-k9 (used as /tmp filesystem when enabled) |
+| k9.storage.existingClaim | string | `""` | Use existing PVC instead of creating a new one |
+| k9.storage.labels | object | `{}` | Additional labels for the PVC |
+| k9.storage.mountPath | string | `"/tmp"` | Mount path for the persistent volume in the k9 containers (used as /tmp when enabled) |
+| k9.storage.selector | object | `{}` | Selector for the PV (optional) |
+| k9.storage.size | string | `"1Gi"` | Storage size for k9 persistent volume |
+| k9.storage.storageClass | string | `""` | Storage class to use. Use "" for default storage class, "-" for no storage class |
 | k9.tolerations | list | `[]` |  |
 | openshift.enabled | bool | `false` |  |
 | priorityClass.description | string | `"The priority class for RAD Security components"` |  |
@@ -556,7 +598,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | runtime.agent.resources.requests.cpu | string | `"100m"` |  |
 | runtime.agent.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | runtime.agent.resources.requests.memory | string | `"128Mi"` |  |
-| runtime.enabled | bool | `false` |  |
+| runtime.enabled | bool | `true` |  |
 | runtime.exporter.env.LOG_LEVEL | string | `"INFO"` |  |
 | runtime.exporter.execFilters | list | `[]` | Allows to specify wildcard rules for filtering command arguments. |
 | runtime.exporter.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-runtime-exporter"` |  |
@@ -606,6 +648,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | sbom.resources.requests.ephemeral-storage | string | `"1Gi"` |  |
 | sbom.resources.requests.memory | string | `"1Gi"` |  |
 | sbom.serviceAccountAnnotations | object | `{}` |  |
+| sbom.storage | object | `{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":false,"existingClaim":"","labels":{},"mountPath":"/tmp","selector":{},"size":"25Gi","storageClass":""}` | Storage configuration for rad-sbom |
+| sbom.storage.accessModes | list | `["ReadWriteOnce"]` | Access modes for the PVC |
+| sbom.storage.annotations | object | `{}` | Additional annotations for the PVC |
+| sbom.storage.enabled | bool | `false` | Enable persistent storage for rad-sbom (used as /tmp for image processing and layer caching) |
+| sbom.storage.existingClaim | string | `""` | Use existing PVC instead of creating a new one |
+| sbom.storage.labels | object | `{}` | Additional labels for the PVC |
+| sbom.storage.mountPath | string | `"/tmp"` | Mount path for the persistent volume in the SBOM container (also used as /tmp when enabled) |
+| sbom.storage.selector | object | `{}` | Selector for the PV (optional) |
+| sbom.storage.size | string | `"25Gi"` | Storage size for SBOM persistent volume (larger size recommended for image processing) |
+| sbom.storage.storageClass | string | `""` | Storage class to use. Use "" for default storage class, "-" for no storage class |
 | sbom.tolerations | list | `[]` |  |
 | sbom.webhook.timeoutSeconds | int | `10` |  |
 | sync.enabled | bool | `true` |  |
@@ -621,6 +673,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | sync.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | sync.resources.requests.memory | string | `"128Mi"` |  |
 | sync.serviceAccountAnnotations | object | `{}` |  |
+| sync.storage | object | `{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":false,"existingClaim":"","labels":{},"mountPath":"/tmp","selector":{},"size":"1Gi","storageClass":""}` | Storage configuration for rad-sync |
+| sync.storage.accessModes | list | `["ReadWriteOnce"]` | Access modes for the PVC |
+| sync.storage.annotations | object | `{}` | Additional annotations for the PVC |
+| sync.storage.enabled | bool | `false` | Enable persistent storage for rad-sync (used as /tmp filesystem when enabled) |
+| sync.storage.existingClaim | string | `""` | Use existing PVC instead of creating a new one |
+| sync.storage.labels | object | `{}` | Additional labels for the PVC |
+| sync.storage.mountPath | string | `"/tmp"` | Mount path for the persistent volume in the sync container (used as /tmp when enabled) |
+| sync.storage.selector | object | `{}` | Selector for the PV (optional) |
+| sync.storage.size | string | `"1Gi"` | Storage size for sync persistent volume |
+| sync.storage.storageClass | string | `""` | Storage class to use. Use "" for default storage class, "-" for no storage class |
 | sync.tolerations | list | `[]` |  |
 | watch.customResourceRules | object | `{"allowlist":[],"denylist":[]}` | Rules for Custom Resource ingestion containing allow- and denylists of rules specifying `apiGroups` and `resources`. E.g. `allowlist: apiGroups: ["custom.com"], resources: ["someResource", "otherResoure"]` Wildcards (`*`) can be used to match all. `customResourceRules.denylist` sets resources that should not be ingested. It has a priority over `customResourceRules.allowlist` to  deny resources allowed using a wildcard (`*`) match.  E.g. you can use `allowlist: apiGroups: ["custom.com"], resources: ["*"], denylist: apiGroups: ["custom.com"], resources: "excluded"` to ingest all resources within `custom.com` group but `excluded`. |
 | watch.enabled | bool | `true` |  |
@@ -637,6 +699,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | watch.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | watch.resources.requests.memory | string | `"128Mi"` |  |
 | watch.serviceAccountAnnotations | object | `{}` |  |
+| watch.storage | object | `{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":false,"existingClaim":"","labels":{},"mountPath":"/tmp","selector":{},"size":"1Gi","storageClass":""}` | Storage configuration for rad-watch |
+| watch.storage.accessModes | list | `["ReadWriteOnce"]` | Access modes for the PVC |
+| watch.storage.annotations | object | `{}` | Additional annotations for the PVC |
+| watch.storage.enabled | bool | `false` | Enable persistent storage for rad-watch (used as /tmp filesystem when enabled) |
+| watch.storage.existingClaim | string | `""` | Use existing PVC instead of creating a new one |
+| watch.storage.labels | object | `{}` | Additional labels for the PVC |
+| watch.storage.mountPath | string | `"/tmp"` | Mount path for the persistent volume in the watch container (used as /tmp when enabled) |
+| watch.storage.selector | object | `{}` | Selector for the PV (optional) |
+| watch.storage.size | string | `"1Gi"` | Storage size for watch persistent volume |
+| watch.storage.storageClass | string | `""` | Storage class to use. Use "" for default storage class, "-" for no storage class |
 | watch.tolerations | list | `[]` |  |
 | workloads.disableServiceMesh | bool | `true` | Whether to disable service mesh integration. |
 | workloads.imagePullSecretName | string | `""` | The image pull secret name to use to pull container images. |

--- a/stable/rad-plugins/README.md.gotmpl
+++ b/stable/rad-plugins/README.md.gotmpl
@@ -93,7 +93,30 @@ runtime:
 
 Each plugin pod contains `agent` and `exporter` containers. The `agent` container is responsible for collecting runtime information from the nodes in the cluster. The `exporter` container is responsible for exporting the collected information to the RAD Security platform.
 
-The information collected is sent to the RAD Security platform for further processing. For more information on the `rad-runtime
+The information collected is sent to the RAD Security platform for further processing. For more information on the `rad-runtime` plugin, see the [RAD Security documentation](https://docs.rad.security/).
+
+## Persistent Storage
+
+RAD Security plugins support optional persistent storage for enhanced performance and data persistence. When enabled, components use PersistentVolumeClaims (PVCs) as their `/tmp` filesystem instead of ephemeral storage.
+
+
+### Basic Configuration
+
+Enable persistent storage for any component by setting `PLUGIN_NAME.storage.enabled: true`. If `storageClass` is not set, the default StorageClass will be used.
+
+```yaml
+sbom:
+  storage:
+    enabled: true
+    size: 25Gi
+    storageClass: "gp3" # Define custom storage class
+
+guard:
+  storage:
+    enabled: true
+    size: 1Gi
+    storageClass: ""  # Use default storage class
+```
 
 ## Prerequisites
 

--- a/stable/rad-plugins/templates/guard/deployment.yaml
+++ b/stable/rad-plugins/templates/guard/deployment.yaml
@@ -103,6 +103,10 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           volumeMounts:
+          {{- if .Values.guard.storage.enabled }}
+          - mountPath: /tmp
+            name: guard-storage
+          {{- end }}
           - mountPath: /tmp/k8s-webhook-server/serving-certs
             name: cert
             readOnly: true
@@ -127,5 +131,10 @@ spec:
       - name: api-token
         secret:
           secretName: rad-guard-api-token-secret
+      {{- if .Values.guard.storage.enabled }}
+      - name: guard-storage
+        persistentVolumeClaim:
+          claimName: guard
+      {{- end }}
 {{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/guard/pvc.yaml
+++ b/stable/rad-plugins/templates/guard/pvc.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.guard.enabled .Values.guard.storage.enabled (not .Values.guard.storage.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "rad-plugins.storage.guard.pvcName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app_name: rad-guard
+    maintained_by: rad.security
+    {{- with .Values.guard.storage.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.guard.storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.guard.storage.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.guard.storage.size }}
+  {{- if .Values.guard.storage.storageClass }}
+  {{- if ne .Values.guard.storage.storageClass "-" }}
+  storageClassName: {{ .Values.guard.storage.storageClass }}
+  {{- end }}
+  {{- end }}
+  {{- with .Values.guard.storage.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/stable/rad-plugins/templates/rad-k9/deployment.yaml
+++ b/stable/rad-plugins/templates/rad-k9/deployment.yaml
@@ -85,6 +85,10 @@ spec:
           - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
             name: api-token
             readOnly: true
+          {{- if .Values.k9.storage.enabled }}
+          - mountPath: /tmp
+            name: k9
+          {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -153,6 +157,10 @@ spec:
           - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
             name: api-token
             readOnly: true
+          {{- if .Values.k9.storage.enabled }}
+          - mountPath: /tmp
+            name: k9-storage
+          {{- end }}
         livenessProbe:
             httpGet:
               path: /healthz
@@ -172,6 +180,11 @@ spec:
       - name: api-token
         secret:
           secretName: rad-k9-api-token-secret
+      {{- if .Values.k9.storage.enabled }}
+      - name: k9
+        persistentVolumeClaim:
+          claimName: k9
+      {{- end }}
       {{- with .Values.k9.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/stable/rad-plugins/templates/rad-k9/pvc.yaml
+++ b/stable/rad-plugins/templates/rad-k9/pvc.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.k9.enabled .Values.k9.storage.enabled (not .Values.k9.storage.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: k9
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app_name: rad-k9
+    maintained_by: rad.security
+    {{- with .Values.k9.storage.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.k9.storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.k9.storage.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.k9.storage.size }}
+  {{- if .Values.k9.storage.storageClass }}
+  {{- if ne .Values.k9.storage.storageClass "-" }}
+  storageClassName: {{ .Values.k9.storage.storageClass }}
+  {{- end }}
+  {{- end }}
+  {{- with .Values.k9.storage.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/stable/rad-plugins/templates/runtime/daemonset.yaml
+++ b/stable/rad-plugins/templates/runtime/daemonset.yaml
@@ -253,6 +253,7 @@ spec:
           secret:
             secretName: rad-runtime-api-token-secret
         - name: unix-socket
+          emptyDir: {}
         - hostPath:
             path: /bin
             type: ""

--- a/stable/rad-plugins/templates/sbom/deployment.yaml
+++ b/stable/rad-plugins/templates/sbom/deployment.yaml
@@ -104,9 +104,15 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           volumeMounts:
+          {{- if .Values.sbom.storage.enabled }}
+          - mountPath: /tmp
+            name: sbom-storage
+            readOnly: false
+          {{- else }}
           - mountPath: /tmp
             name: temp-image-dir
             readOnly: false
+          {{- end }}
           - mountPath: /tmp/k8s-webhook-server/serving-certs
             name: cert
             readOnly: true
@@ -124,8 +130,10 @@ spec:
 {{ toYaml . | indent 8 }}
   {{- end }}
       volumes:
+      {{- if not .Values.sbom.storage.enabled }}
       - name: temp-image-dir
         emptyDir: {}
+      {{- end }}
       - name: cert
         secret:
           defaultMode: 420
@@ -133,5 +141,10 @@ spec:
       - name: api-token
         secret:
           secretName: rad-sbom-api-token-secret
+      {{- if .Values.sbom.storage.enabled }}
+      - name: sbom-storage
+        persistentVolumeClaim:
+          claimName: sbom
+      {{- end }}
 {{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/sbom/pvc.yaml
+++ b/stable/rad-plugins/templates/sbom/pvc.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.sbom.enabled .Values.sbom.storage.enabled (not .Values.sbom.storage.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sbom
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app_name: rad-sbom
+    maintained_by: rad.security
+    {{- with .Values.sbom.storage.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.sbom.storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.sbom.storage.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.sbom.storage.size }}
+  {{- if .Values.sbom.storage.storageClass }}
+  {{- if ne .Values.sbom.storage.storageClass "-" }}
+  storageClassName: {{ .Values.sbom.storage.storageClass }}
+  {{- end }}
+  {{- end }}
+  {{- with .Values.sbom.storage.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/stable/rad-plugins/templates/sync/deployment.yaml
+++ b/stable/rad-plugins/templates/sync/deployment.yaml
@@ -89,6 +89,10 @@ spec:
               value: "{{ $value }}"
             {{- end }}
           volumeMounts:
+          {{- if .Values.sync.storage.enabled }}
+          - mountPath: /tmp
+            name: sync
+          {{- end }}
           - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
             name: api-token
             readOnly: true
@@ -106,5 +110,10 @@ spec:
       - name: api-token
         secret:
           secretName: rad-sync-api-token-secret
+      {{- if .Values.sync.storage.enabled }}
+      - name: sync
+        persistentVolumeClaim:
+          claimName: sync
+      {{- end }}
 {{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/sync/pvc.yaml
+++ b/stable/rad-plugins/templates/sync/pvc.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.sync.enabled .Values.sync.storage.enabled (not .Values.sync.storage.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sync
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app_name: rad-sync
+    maintained_by: rad.security
+    {{- with .Values.sync.storage.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.sync.storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.sync.storage.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.sync.storage.size }}
+  {{- if .Values.sync.storage.storageClass }}
+  {{- if ne .Values.sync.storage.storageClass "-" }}
+  storageClassName: {{ .Values.sync.storage.storageClass }}
+  {{- end }}
+  {{- end }}
+  {{- with .Values.sync.storage.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/stable/rad-plugins/templates/watch/deployment.yaml
+++ b/stable/rad-plugins/templates/watch/deployment.yaml
@@ -95,6 +95,10 @@ spec:
               value: "{{ $value }}"
             {{- end }}
           volumeMounts:
+          {{- if .Values.watch.storage.enabled }}
+          - mountPath: /tmp
+            name: watch-storage
+          {{- end }}
           - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
             name: api-token
             readOnly: true
@@ -121,6 +125,11 @@ spec:
       - name: custom-resource-rules
         configMap:
           name: rad-watch-custom-resource-rules
+      {{- end }}
+      {{- if .Values.watch.storage.enabled }}
+      - name: watch-storage
+        persistentVolumeClaim:
+          claimName: watch
       {{- end }}
 {{- end -}}
 {{- end -}}

--- a/stable/rad-plugins/templates/watch/pvc.yaml
+++ b/stable/rad-plugins/templates/watch/pvc.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.watch.enabled .Values.watch.storage.enabled (not .Values.watch.storage.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: watch
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app_name: rad-watch
+    maintained_by: rad.security
+    {{- with .Values.watch.storage.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.watch.storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.watch.storage.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.watch.storage.size }}
+  {{- if .Values.watch.storage.storageClass }}
+  {{- if ne .Values.watch.storage.storageClass "-" }}
+  storageClassName: {{ .Values.watch.storage.storageClass }}
+  {{- end }}
+  {{- end }}
+  {{- with .Values.watch.storage.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -98,6 +98,28 @@ guard:
   nodeSelector: {}
   tolerations: []
   serviceAccountAnnotations: {}
+  # -- Storage configuration for rad-guard
+  storage:
+    # -- Enable persistent storage for rad-guard (used as /tmp filesystem when enabled)
+    enabled: false
+    # -- Storage class to use. Use "" for default storage class, "-" for no storage class
+    # -- Common classes: gp2/gp3 (AWS), standard-ssd (GKE), managed-premium (AKS)
+    storageClass: ""
+    # -- Storage size for guard persistent volume
+    size: 1Gi
+    # -- Access modes for the PVC
+    accessModes:
+      - ReadWriteOnce
+    # -- Mount path for the persistent volume in the guard container (used as /tmp when enabled)
+    mountPath: "/tmp"
+    # -- Use existing PVC instead of creating a new one
+    existingClaim: ""
+    # -- Additional labels for the PVC
+    labels: {}
+    # -- Additional annotations for the PVC
+    annotations: {}
+    # -- Selector for the PV (optional)
+    selector: {}
 
 sbom:
   enabled: true
@@ -145,6 +167,27 @@ sbom:
   nodeSelector: {}
   tolerations: []
   serviceAccountAnnotations: {}
+  # -- Storage configuration for rad-sbom
+  storage:
+    # -- Enable persistent storage for rad-sbom (used as /tmp for image processing and layer caching)
+    enabled: false
+    # -- Storage class to use. Use "" for default storage class, "-" for no storage class
+    storageClass: ""
+    # -- Storage size for SBOM persistent volume (larger size recommended for image processing)
+    size: 25Gi
+    # -- Access modes for the PVC
+    accessModes:
+      - ReadWriteOnce
+    # -- Mount path for the persistent volume in the SBOM container (also used as /tmp when enabled)
+    mountPath: "/tmp"
+    # -- Use existing PVC instead of creating a new one
+    existingClaim: ""
+    # -- Additional labels for the PVC
+    labels: {}
+    # -- Additional annotations for the PVC
+    annotations: {}
+    # -- Selector for the PV (optional)
+    selector: {}
 
 sync:
   enabled: true
@@ -166,6 +209,27 @@ sync:
   nodeSelector: {}
   tolerations: []
   serviceAccountAnnotations: {}
+  # -- Storage configuration for rad-sync
+  storage:
+    # -- Enable persistent storage for rad-sync (used as /tmp filesystem when enabled)
+    enabled: false
+    # -- Storage class to use. Use "" for default storage class, "-" for no storage class
+    storageClass: ""
+    # -- Storage size for sync persistent volume
+    size: 1Gi
+    # -- Access modes for the PVC
+    accessModes:
+      - ReadWriteOnce
+    # -- Mount path for the persistent volume in the sync container (used as /tmp when enabled)
+    mountPath: "/tmp"
+    # -- Use existing PVC instead of creating a new one
+    existingClaim: ""
+    # -- Additional labels for the PVC
+    labels: {}
+    # -- Additional annotations for the PVC
+    annotations: {}
+    # -- Selector for the PV (optional)
+    selector: {}
 
 watch:
   enabled: true
@@ -202,9 +266,30 @@ watch:
     allowlist: []
     denylist: []
   serviceAccountAnnotations: {}
+  # -- Storage configuration for rad-watch
+  storage:
+    # -- Enable persistent storage for rad-watch (used as /tmp filesystem when enabled)
+    enabled: false
+    # -- Storage class to use. Use "" for default storage class, "-" for no storage class
+    storageClass: ""
+    # -- Storage size for watch persistent volume
+    size: 1Gi
+    # -- Access modes for the PVC
+    accessModes:
+      - ReadWriteOnce
+    # -- Mount path for the persistent volume in the watch container (used as /tmp when enabled)
+    mountPath: "/tmp"
+    # -- Use existing PVC instead of creating a new one
+    existingClaim: ""
+    # -- Additional labels for the PVC
+    labels: {}
+    # -- Additional annotations for the PVC
+    annotations: {}
+    # -- Selector for the PV (optional)
+    selector: {}
 
 runtime:
-  enabled: false
+  enabled: true
   reachableVulnerabilitiesEnabled: true
   httpTracingEnabled: false
   agent:
@@ -334,6 +419,27 @@ k9:
   tolerations: []
   nodeSelector: {}
   serviceAccountAnnotations: {}
+  # -- Storage configuration for rad-k9
+  storage:
+    # -- Enable persistent storage for rad-k9 (used as /tmp filesystem when enabled)
+    enabled: false
+    # -- Storage class to use. Use "" for default storage class, "-" for no storage class
+    storageClass: ""
+    # -- Storage size for k9 persistent volume
+    size: 1Gi
+    # -- Access modes for the PVC
+    accessModes:
+      - ReadWriteOnce
+    # -- Mount path for the persistent volume in the k9 containers (used as /tmp when enabled)
+    mountPath: "/tmp"
+    # -- Use existing PVC instead of creating a new one
+    existingClaim: ""
+    # -- Additional labels for the PVC
+    labels: {}
+    # -- Additional annotations for the PVC
+    annotations: {}
+    # -- Selector for the PV (optional)
+    selector: {}
 
 # Enables support for OpenShift.
 openshift:


### PR DESCRIPTION
Adds PVC support for plugins for `/tmp`. The runtimer is not able to use PVCs since it runs as a Daemonset. The helm chart is configured to allow customers to use existing PVCs, and to configure the storageClass and write mode based on what is configured in their Kubernetes environment. 

For watch to have pvcs enabled, we would need to set the following:
```yaml
watch:
  enabled: true
  storage:
    enabled: true
    storageClass: gp3-delete
```

That would result in the following pvc being created. 
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  labels:
    app_name: rad-watch
    maintained_by: rad.security
  name: watch
  namespace: rad
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  storageClassName: gp3-delete
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
```



#### Checklist

- [X] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [X] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [X] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
