### PR TITLE
Fix default in ephemeral volume creation in piiAnalyzer

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.3.26
+version: 2.3.27
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/apple-touch-icon-180x180.png
@@ -17,8 +17,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: added
-      description: Adds support for pvc for /tmp mounts in plugins
+    - kind: fixed
+      description: Disables ephemeral storage creation for piiAnalyzer plugin by default
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -637,10 +637,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | runtime.nodeSelector | object | `{}` |  |
 | runtime.piiAnalyzer.enabled | bool | `false` |  |
 | runtime.piiAnalyzer.env.LOG_LEVEL | string | `"WARNING"` |  |
-| runtime.piiAnalyzer.ephemeralVolumes | object | `{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":true,"labels":{},"mountPath":"/tmp","size":"1Gi","storageClassName":""}` | Ephemeral volume configuration for pii-analyzer |
+| runtime.piiAnalyzer.ephemeralVolumes | object | `{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":false,"labels":{},"mountPath":"/tmp","size":"1Gi","storageClassName":""}` | Ephemeral volume configuration for pii-analyzer |
 | runtime.piiAnalyzer.ephemeralVolumes.accessModes | list | `["ReadWriteOnce"]` | Access modes for the ephemeral volume |
 | runtime.piiAnalyzer.ephemeralVolumes.annotations | object | `{}` | Additional annotations for the ephemeral volume |
-| runtime.piiAnalyzer.ephemeralVolumes.enabled | bool | `true` | Enable ephemeral storage for pii-analyzer (used for temporary processing) |
+| runtime.piiAnalyzer.ephemeralVolumes.enabled | bool | `false` | Enable ephemeral storage for pii-analyzer (used for temporary processing) |
 | runtime.piiAnalyzer.ephemeralVolumes.labels | object | `{}` | Additional labels for the ephemeral volume |
 | runtime.piiAnalyzer.ephemeralVolumes.mountPath | string | `"/tmp"` | Mount path for the ephemeral volume |
 | runtime.piiAnalyzer.ephemeralVolumes.size | string | `"1Gi"` | Storage size for ephemeral volume |

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -364,7 +364,7 @@ runtime:
     # -- Ephemeral volume configuration for pii-analyzer
     ephemeralVolumes:
       # -- Enable ephemeral storage for pii-analyzer (used for temporary processing)
-      enabled: true
+      enabled: false
       # -- Storage class to use. Use "" for default storage class, "-" for no storage class
       storageClassName: ""
       # -- Access modes for the ephemeral volume


### PR DESCRIPTION
Fixes a default value where ephmeral volume creation was set to true for the piiAnalyzer

#### Checklist

- [X] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [X] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [X] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
