### PR TITLE
Lower default PriorityClass value

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.3.28
+version: 2.3.29
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/apple-touch-icon-180x180.png

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -577,7 +577,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | priorityClass.globalDefault | bool | `false` |  |
 | priorityClass.name | string | `"rad-priority"` |  |
 | priorityClass.preemptionPolicy | string | `"PreemptLowerPriority"` |  |
-| priorityClass.value | int | `1000000000` |  |
+| priorityClass.value | int | `10` |  |
 | rad.accessKeySecretNameOverride | string | `""` | The name of the custom secret containing Access Key. |
 | rad.apiKey | string | `""` | The combined API key to authenticate with RAD Security |
 | rad.apiUrl | string | `"https://api.rad.security"` | The base URL for the RAD Security API. |

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -40,7 +40,7 @@ workloads:
 priorityClass:
   enabled: false
   name: rad-priority
-  value: 1000000000
+  value: 10
   globalDefault: false
   description: "The priority class for RAD Security components"
   preemptionPolicy: PreemptLowerPriority


### PR DESCRIPTION
#### What this PR does / why we need it
Lower the default PriorityClass value for RAD plugins to limit preemption.  `preemptionPolicy: Never` remains an option as well.

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
