### PR TITLE
Bump cert manager helm chart version

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.4.1
+version: 2.4.2
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/assets/favicon.svg
@@ -17,14 +17,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: removed
-      description: Remove rad-k9 plugin
-    - kind: added
-      description: Add k9 plugin functionality to rad-sync and migrate its RBAC permissions to rad-sync
     - kind: security
-      description: Bump version of all plugins to fix vulnerabilities
-    - kind: added
-      description: Improved runtime DNS mapping
+      description: Bump documentation to use newest version of the cert-manager helm chart
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -242,7 +242,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.16.0 \
+  --version v1.19.2 \
   --set installCRDs=true
 ```
 

--- a/stable/rad-plugins/README.md.gotmpl
+++ b/stable/rad-plugins/README.md.gotmpl
@@ -242,7 +242,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.16.0 \
+  --version v1.19.2 \
   --set installCRDs=true
 ```
 


### PR DESCRIPTION
#### What this PR does / why we need it
Bump cert manager helm chart version in the documentation

#### Checklist

- [x] [DCO](https://github.com/rad-security/plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/rad-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/rad-plugins/README.md.gotmpl) and [README.md](./stable/rad-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/rad-plugins/Chart.yaml) section updated
