### PR TITLE
Bump rad-guard and rad-sbom for security fixes

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.4.2
+version: 2.4.3
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/assets/favicon.svg
@@ -18,7 +18,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: security
-      description: Bump documentation to use newest version of the cert-manager helm chart
+      description: Bump rad-guard to v1.1.36 and rad-sbom to v1.1.60 to fix security vulnerabilities
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -604,7 +604,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | guard.ephemeralVolumes.size | string | `"1Gi"` | Storage size for guard ephemeral volume |
 | guard.ephemeralVolumes.storageClassName | string | `""` | Storage class to use. Use "" for default storage class, "-" for no storage class |
 | guard.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-guard"` | The image to use for the rad-guard deployment |
-| guard.image.tag | string | `"v1.1.35"` |  |
+| guard.image.tag | string | `"v1.1.36"` |  |
 | guard.nodeSelector | object | `{}` |  |
 | guard.podAnnotations | object | `{}` |  |
 | guard.replicas | int | `1` |  |
@@ -734,7 +734,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | sbom.ephemeralVolumes.size | string | `"25Gi"` | Storage size for SBOM ephemeral volume (larger size recommended for image processing) |
 | sbom.ephemeralVolumes.storageClassName | string | `""` | Storage class to use. Use "" for default storage class, "-" for no storage class |
 | sbom.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-sbom"` | The image to use for the rad-sbom deployment |
-| sbom.image.tag | string | `"v1.1.59"` |  |
+| sbom.image.tag | string | `"v1.1.60"` |  |
 | sbom.labels | object | `{}` |  |
 | sbom.nodeSelector | object | `{}` |  |
 | sbom.podAnnotations | object | `{}` |  |

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -70,7 +70,7 @@ guard:
   image:
     # -- The image to use for the rad-guard deployment
     repository: public.ecr.aws/n8h5y2v5/rad-security/rad-guard
-    tag: v1.1.35
+    tag: v1.1.36
   config:
     # -- Whether to block on error.
     BLOCK_ON_ERROR: false
@@ -123,7 +123,7 @@ sbom:
   image:
     # -- The image to use for the rad-sbom deployment
     repository: public.ecr.aws/n8h5y2v5/rad-security/rad-sbom
-    tag: v1.1.59
+    tag: v1.1.60
   env:
     # -- Whether to mutate the image in pod spec by adding digest at the end. By default, digests are added to images to ensure
     # that the image that runs in the cluster matches the digest of the build.  Disable this if your continuous deployment


### PR DESCRIPTION
## Summary
- Bump rad-guard from v1.1.35 to v1.1.36 to address security vulnerabilities
- Bump rad-sbom from v1.1.59 to v1.1.60 to address security vulnerabilities
- Bump chart version from 2.4.2 to 2.4.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)