### PR TITLE
chore: bump rad-bootstrapper to v1.1.32 and rad-guard to v1.1.42

### DIFF
--- a/stable/rad-plugins/Chart.yaml
+++ b/stable/rad-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rad-plugins
-version: 2.4.11
+version: 2.4.12
 description: A Helm chart to run the RAD Security plugins
 home: https://rad.security
 icon: https://app.rad.security/assets/favicon.svg
@@ -17,8 +17,10 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
+    - kind: fixed
+      description: rad-bootstrapper keeps the cluster identity stable when the control plane republishes or rotates the cluster CA, instead of registering the cluster again
     - kind: security
-      description: Bump all plugin image tags to Go 1.26.5 and patched dependencies (containerd, mongo-driver, oras) to fix security vulnerabilities
+      description: Bump rad-guard to v1.1.42 for dd-trace-go CVE-2026-50274
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/rad-plugins/README.md
+++ b/stable/rad-plugins/README.md
@@ -578,7 +578,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | bootstrapper.affinity | object | `{}` |  |
 | bootstrapper.env | object | `{}` |  |
 | bootstrapper.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-bootstrapper"` | The image to use for the rad-bootstrapper deployment |
-| bootstrapper.image.tag | string | `"v1.1.31"` |  |
+| bootstrapper.image.tag | string | `"v1.1.32"` |  |
 | bootstrapper.nodeSelector | object | `{}` |  |
 | bootstrapper.podAnnotations | object | `{}` |  |
 | bootstrapper.resources.limits.cpu | string | `"100m"` |  |
@@ -604,7 +604,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | guard.ephemeralVolumes.size | string | `"1Gi"` | Storage size for guard ephemeral volume |
 | guard.ephemeralVolumes.storageClassName | string | `""` | Storage class to use. Use "" for default storage class, "-" for no storage class |
 | guard.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-guard"` | The image to use for the rad-guard deployment |
-| guard.image.tag | string | `"v1.1.41"` |  |
+| guard.image.tag | string | `"v1.1.42"` |  |
 | guard.nodeSelector | object | `{}` |  |
 | guard.podAnnotations | object | `{}` |  |
 | guard.replicas | int | `1` |  |

--- a/stable/rad-plugins/values.yaml
+++ b/stable/rad-plugins/values.yaml
@@ -49,7 +49,7 @@ bootstrapper:
   image:
     # -- The image to use for the rad-bootstrapper deployment
     repository: public.ecr.aws/n8h5y2v5/rad-security/rad-bootstrapper
-    tag: v1.1.31
+    tag: v1.1.32
   env: {}
   resources:
     limits:
@@ -70,7 +70,7 @@ guard:
   image:
     # -- The image to use for the rad-guard deployment
     repository: public.ecr.aws/n8h5y2v5/rad-security/rad-guard
-    tag: v1.1.41
+    tag: v1.1.42
   config:
     # -- Whether to block on error.
     BLOCK_ON_ERROR: false


### PR DESCRIPTION
## Summary

- `rad-bootstrapper` `v1.1.31` → `v1.1.32`
- `rad-guard` `v1.1.41` → `v1.1.42`
- Chart `2.4.11` → `2.4.12`, README regenerated with helm-docs

**rad-bootstrapper** picks up [mod-libs v1.2.51](https://github.com/ksoc-private/mod-libs/pull/105) via [plugin-ksoc-bootstrapper#119](https://github.com/ksoc-private/plugin-ksoc-bootstrapper/pull/119). The cluster id is now anchored on the **oldest** certificate in `kube-root-ca.crt` rather than a digest of the bundle verbatim, so a control plane that republishes the CA twice, reorders it, or adds an incoming CA mid-rotation no longer changes the id.

Without it the backend does not recognise the reported digest, tries to register the cluster a second time, and rejects the plugin with `access key used by different cluster` (401). That took RAD PROD out on 2026-07-17 after `pe-sbx` hit the same thing on 2026-07-16 — a staggered pattern that suggests customer EKS clusters were affected too.

**rad-guard** picks up dd-trace-go `v2.9.1` for CVE-2026-50274.

## Verification

- `helm lint stable/rad-plugins` passes.
- `helm template` renders `rad-bootstrapper:v1.1.32` and `rad-guard:v1.1.42`.
- All pre-commit hooks pass, including the helm-docs check.
- `rad-bootstrapper:v1.1.32` is published to public ECR.

> ⚠️ `rad-guard:v1.1.42` was **not yet published to ECR** at the time of writing — the git tag was cut minutes earlier and the image build was still in flight. Same "point at the forthcoming release" pattern as the previous bump, but worth confirming the image has landed before this rolls out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)